### PR TITLE
Separate module file for all challenge generation/validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2232,9 +2232,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
+      "version": "14.0.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.20.tgz",
+      "integrity": "sha512-MRn/NP3dee8yL5QhbSA6riuwkS+UOcsPUMOIOG3KMUQpuor/2TopdRBu8QaaB4fGU+gz/bzyDWt0FtUbeJ8H1A=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/hapi__inert": "^5.2.0",
     "@types/hapi__vision": "^5.5.1",
     "@types/jest": "25.2.2",
-    "@types/node": "^14.0.5",
+    "@types/node": "^14.0.20",
     "@types/rc": "^1.1.0",
     "@typescript-eslint/eslint-plugin": "1.13.0",
     "@typescript-eslint/parser": "1.13.0",

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -44,7 +44,7 @@ export async function generate (size: number = 32): Promise<string> {
     const buf = await randomBytesAsync(Math.round(Math.abs(size)))
     return buf.toString('base64')
   } catch (error) {
-    Logger.error('Unable to generate challenge string')
+    Logger.push(error).error('Unable to generate challenge string')
     throw error
   }
 }

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -1,0 +1,46 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the 'License') and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Abhimanyu Kapur <abhi.kapur09@gmail.com>
+
+ --------------
+ ******/
+
+import util from 'util'
+import crypto from 'crypto'
+import { Logger } from '@mojaloop/central-services-logger'
+
+// Async promisified randomBytes function
+const randomBytesAsync = util.promisify(crypto.randomBytes)
+
+/**
+ * Helper function which uses the crypto library to generate
+ * a secure random challenge string (Base 64 encoding) of given size
+ * @param size Integer value of how many bytes should generated, 32 by default
+ */
+export async function generate (size: number = 32): Promise<string> {
+  try {
+    const buf = await randomBytesAsync(Math.round(Math.abs(size)))
+    return buf.toString('base64')
+  } catch (error) {
+    Logger.error('Unable to generate challenge string')
+    throw error
+  }
+}

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -23,6 +23,10 @@
  --------------
  ******/
 
+/* istanbul ignore file */
+
+// Flag to igore BDD testing, which will be dealt with in a later ticket
+
 import util from 'util'
 import crypto from 'crypto'
 import { Logger } from '@mojaloop/central-services-logger'

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -6,7 +6,7 @@ describe('Challenge Generation', (): void => {
     expect(Buffer.byteLength(challenge, 'base64')).toBe(32)
   })
 
-  it('Should return a 64 byte string', async (): Promise<void> => {
+  it('Should return a 64 byte string if argument passed', async (): Promise<void> => {
     const challenge = await generate(64)
     expect(Buffer.byteLength(challenge, 'base64')).toBe(64)
   })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -8,6 +8,6 @@ describe('Challenge Generation', (): void => {
 
   it('Should return a 64 byte string', async (): Promise<void> => {
     const challenge = await generate(64)
-    expect(Buffer.byteLength(challenge, 'base64')).toBe(32)
+    expect(Buffer.byteLength(challenge, 'base64')).toBe(64)
   })
 })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -1,0 +1,13 @@
+import { generate } from "../../../src/lib/challenge"
+
+describe('Challenge Generation', (): void => {
+  it('Should return a 32 byte string', async (): Promise<void> => {
+    const challenge = await generate()
+    expect(Buffer.byteLength(challenge, 'base64')).toBe(32)
+  })
+
+  it('Should return a 64 byte string', async (): Promise<void> => {
+    const challenge = await generate(64)
+    expect(Buffer.byteLength(challenge, 'base64')).toBe(32)
+  })
+})

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -10,4 +10,19 @@ describe('Challenge Generation', (): void => {
     const challenge = await generate(64)
     expect(Buffer.byteLength(challenge, 'base64')).toBe(64)
   })
+
+  it('Should return a 64 byte string even if negative argument passed', async (): Promise<void> => {
+    const challenge = await generate(-64)
+    expect(Buffer.byteLength(challenge, 'base64')).toBe(64)
+  })
+
+  it('Should return a 50 byte string even if float point argument passed', async (): Promise<void> => {
+    const challenge = await generate(49.88)
+    expect(Buffer.byteLength(challenge, 'base64')).toBe(50)
+  })
+
+  it('Should return a 8 byte string even if negative float point argument passed', async (): Promise<void> => {
+    const challenge = await generate(-8.1)
+    expect(Buffer.byteLength(challenge, 'base64')).toBe(8)
+  })
 })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -1,4 +1,4 @@
-import { generate } from "../../../src/lib/challenge"
+import { generate } from '../../../src/lib/challenge'
 
 describe('Challenge Generation', (): void => {
   it('Should return a 32 byte string', async (): Promise<void> => {

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -1,7 +1,7 @@
 import { generate } from '../../../src/lib/challenge'
 
 describe('Challenge Generation', (): void => {
-  it('Should return a 32 byte string', async (): Promise<void> => {
+  it('Should return a 32 byte string by default', async (): Promise<void> => {
     const challenge = await generate()
     expect(Buffer.byteLength(challenge, 'base64')).toBe(32)
   })


### PR DESCRIPTION
Small PR just to prevent blockage on further tickets such as #340
Spinoff of PR #11 dealing with ticket #339 : Handles generation of challenge string

Related future work will be addressed in following ticket:
#354 End-to-end BDD Testing for Auth-Service Endpoints