### PR TITLE
Feature/342: Add Signature Verification function to Challenge module

### DIFF
--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -32,7 +32,7 @@
  */
 
 import util from 'util'
-import crypto, { KeyObject } from 'crypto'
+import crypto from 'crypto'
 import { Logger } from '@mojaloop/central-services-logger'
 
 // Async promisified randomBytes function
@@ -53,16 +53,16 @@ export async function generate (size: number = 32): Promise<string> {
   }
 }
 
-/*
+/**
  * Helper function to validate signatures using public key
- * @param challenge Base64 challenge string
+ * @param challenge UTF-8 challenge string
  * @param signature Base64 sign string
  * @param publicKey Base64 RSA/EC:secp256k1 key string or KeyObject for verification
  */
-export async function verifySign (
+export function verifySign (
   challenge: string,
   signature: string,
-  publicKey: string | KeyObject): Promise<boolean> {
+  publicKey: string | crypto.KeyObject): boolean {
   // Hash using SHA256
   const verifier: crypto.Verify = crypto.createVerify('SHA256')
 

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -57,13 +57,13 @@ export async function generate (size: number = 32): Promise<string> {
 /**
  * Helper function to validate signatures using public key
  * @param challenge UTF-8 challenge string
- * @param signature Base64 sign string
+ * @param signature Base64 signature string
  * @param publicKey PEM Base64 Public key string or KeyObject for verification
  *
  * Currently, the implementation focuses on RSA 2048 and ECDSA:secp256k1 keys.
  * Support for additional keys can be extended further.
  */
-export function verifySign (
+export function verifySignature (
   challenge: string,
   signature: string,
   publicKey: string | crypto.KeyObject): boolean {

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -58,21 +58,24 @@ export async function generate (size: number = 32): Promise<string> {
  * Helper function to validate signatures using public key
  * @param challenge UTF-8 challenge string
  * @param signature Base64 sign string
- * @param publicKey Base64 RSA/EC:secp256k1 key string or KeyObject for verification
+ * @param publicKey PEM Base64 Public key string or KeyObject for verification
+ *
+ * Currently, the implementation focuses on RSA and ECDSA:secp256k1 keys.
+ * Support for additional keys can be extended further.
  */
 export function verifySign (
   challenge: string,
   signature: string,
   publicKey: string | crypto.KeyObject): boolean {
   try {
-    // Hash using SHA256
+    // Digest Algorithm
     const verifier: crypto.Verify = crypto.createVerify('SHA256')
-
+    // Hashing the challenge string
     verifier.update(challenge)
 
     return verifier.verify(publicKey, signature, 'base64')
   } catch (error) {
-    Logger.push(error).error('Unable to verify signature')
+    Logger.error('Unable to verify signature')
     throw error
   }
 }

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -70,3 +70,5 @@ export function verifySign (
 
   return verifier.verify(publicKey, signature, 'base64')
 }
+
+// Can createVerify be declared once in a beforeEach or global?

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -63,12 +63,15 @@ export function verifySign (
   challenge: string,
   signature: string,
   publicKey: string | crypto.KeyObject): boolean {
-  // Hash using SHA256
-  const verifier: crypto.Verify = crypto.createVerify('SHA256')
+  try {
+    // Hash using SHA256
+    const verifier: crypto.Verify = crypto.createVerify('SHA256')
 
-  verifier.update(challenge)
+    verifier.update(challenge)
 
-  return verifier.verify(publicKey, signature, 'base64')
+    return verifier.verify(publicKey, signature, 'base64')
+  } catch (error) {
+    Logger.push(error).error('Unable to verify signature')
+    throw error
+  }
 }
-
-// Can createVerify be declared once in a beforeEach or global?

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -19,13 +19,17 @@
  - Name Surname <name.surname@gatesfoundation.com>
 
  - Abhimanyu Kapur <abhi.kapur09@gmail.com>
+ - Raman Mangla <ramanmangla@google.com>
 
  --------------
  ******/
 
 /* istanbul ignore file */
 
-// Flag to igore BDD testing, which will be dealt with in a later ticket
+/**
+ * Flag to ignore BDD testing, which will be dealt
+ * with in a later ticket
+ */
 
 import util from 'util'
 import crypto from 'crypto'
@@ -47,4 +51,23 @@ export async function generate (size: number = 32): Promise<string> {
     Logger.push(error).error('Unable to generate challenge string')
     throw error
   }
+}
+
+/*
+ * Helper function to validate signatures using public key
+ */
+export async function verify (challenge: string, signature: string, key: string): Promise<boolean> {
+  // const challengeBuffer = Buffer.from(challenge, 'base64')
+  // const signatureBuffer = Buffer.from(signature, 'base64')
+
+  // return crypto.verify(signAlgorithm, challengeBuffer, key, signatureBuffer)
+  // const verify = crypto.createVerify('RSA-SHA256')
+  // verify.update(challenge, 'utf8')
+  // return verify.verify(key, signature)
+
+  const verifier: crypto.Verify = crypto.createVerify('sha256')
+
+  verifier.update(challenge)
+
+  return verifier.verify(key, signature, 'base64')
 }

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -53,21 +53,16 @@ export async function generate (size: number = 32): Promise<string> {
   }
 }
 
-/*
+/**
  * Helper function to validate signatures using public key
+ * @param challenge Base64 challenge string
+ * @param signature Base64 sign string
+ * @param publicKey Base64/PEM Public key string for verification
  */
-export async function verifySign (challenge: string, signature: string, key: string): Promise<boolean> {
-  // const challengeBuffer = Buffer.from(challenge, 'base64')
-  // const signatureBuffer = Buffer.from(signature, 'base64')
-
-  // return crypto.verify(signAlgorithm, challengeBuffer, key, signatureBuffer)
-  // const verify = crypto.createVerify('RSA-SHA256')
-  // verify.update(challenge, 'utf8')
-  // return verify.verify(key, signature)
-
-  const verifier: crypto.Verify = crypto.createVerify('sha256')
+export async function verifySign (challenge: string, signature: string, publicKey: string): Promise<boolean> {
+  const verifier: crypto.Verify = crypto.createVerify('RSA-SHA256')
 
   verifier.update(challenge)
 
-  return verifier.verify(key, signature, 'base64')
+  return verifier.verify(publicKey, signature, 'base64')
 }

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -27,8 +27,9 @@
 /* istanbul ignore file */
 
 /*
- * Flag to ignore BDD testing, which will be dealt
- * with in a later ticket
+ * This flag is to ignore BDD testing for model
+ * which will be addressed in the future in
+ * ticket #354
  */
 
 import util from 'util'

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -57,7 +57,7 @@ export async function generate (size: number = 32): Promise<string> {
  * Helper function to validate signatures using public key
  * @param challenge Base64 challenge string
  * @param signature Base64 sign string
- * @param publicKey Base64 RSA/EC:sec256k1 key string or KeyObject for verification
+ * @param publicKey Base64 RSA/EC:secp256k1 key string or KeyObject for verification
  */
 export async function verifySign (
   challenge: string,

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -57,9 +57,13 @@ export async function generate (size: number = 32): Promise<string> {
  * Helper function to validate signatures using public key
  * @param challenge Base64 challenge string
  * @param signature Base64 sign string
- * @param publicKey Base64/PEM Public key string or KeyObject for verification
+ * @param publicKey Base64 RSA/EC:sec256k1 key string or KeyObject for verification
  */
-export async function verifySign (challenge: string, signature: string, publicKey: string | KeyObject): Promise<boolean> {
+export async function verifySign (
+  challenge: string,
+  signature: string,
+  publicKey: string | KeyObject): Promise<boolean> {
+  // Hash using SHA256
   const verifier: crypto.Verify = crypto.createVerify('SHA256')
 
   verifier.update(challenge)

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -60,7 +60,7 @@ export async function generate (size: number = 32): Promise<string> {
  * @param signature Base64 sign string
  * @param publicKey PEM Base64 Public key string or KeyObject for verification
  *
- * Currently, the implementation focuses on RSA and ECDSA:secp256k1 keys.
+ * Currently, the implementation focuses on RSA 2048 and ECDSA:secp256k1 keys.
  * Support for additional keys can be extended further.
  */
 export function verifySign (

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -53,14 +53,14 @@ export async function generate (size: number = 32): Promise<string> {
   }
 }
 
-/**
+/*
  * Helper function to validate signatures using public key
  * @param challenge Base64 challenge string
  * @param signature Base64 sign string
  * @param publicKey Base64/PEM Public key string for verification
  */
 export async function verifySign (challenge: string, signature: string, publicKey: string): Promise<boolean> {
-  const verifier: crypto.Verify = crypto.createVerify('RSA-SHA256')
+  const verifier: crypto.Verify = crypto.createVerify('SHA256')
 
   verifier.update(challenge)
 

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -34,7 +34,7 @@
 
 import util from 'util'
 import crypto from 'crypto'
-import { Logger } from '@mojaloop/central-services-logger'
+import Logger from '@mojaloop/central-services-logger'
 
 // Async promisified randomBytes function
 const randomBytesAsync = util.promisify(crypto.randomBytes)
@@ -75,6 +75,7 @@ export function verifySign (
 
     return verifier.verify(publicKey, signature, 'base64')
   } catch (error) {
+    Logger.push(error)
     Logger.error('Unable to verify signature')
     throw error
   }

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -32,7 +32,7 @@
  */
 
 import util from 'util'
-import crypto from 'crypto'
+import crypto, { KeyObject } from 'crypto'
 import { Logger } from '@mojaloop/central-services-logger'
 
 // Async promisified randomBytes function
@@ -57,9 +57,9 @@ export async function generate (size: number = 32): Promise<string> {
  * Helper function to validate signatures using public key
  * @param challenge Base64 challenge string
  * @param signature Base64 sign string
- * @param publicKey Base64/PEM Public key string for verification
+ * @param publicKey Base64/PEM Public key string or KeyObject for verification
  */
-export async function verifySign (challenge: string, signature: string, publicKey: string): Promise<boolean> {
+export async function verifySign (challenge: string, signature: string, publicKey: string | KeyObject): Promise<boolean> {
   const verifier: crypto.Verify = crypto.createVerify('SHA256')
 
   verifier.update(challenge)

--- a/src/lib/challenge.ts
+++ b/src/lib/challenge.ts
@@ -26,7 +26,7 @@
 
 /* istanbul ignore file */
 
-/**
+/*
  * Flag to ignore BDD testing, which will be dealt
  * with in a later ticket
  */
@@ -56,7 +56,7 @@ export async function generate (size: number = 32): Promise<string> {
 /*
  * Helper function to validate signatures using public key
  */
-export async function verify (challenge: string, signature: string, key: string): Promise<boolean> {
+export async function verifySign (challenge: string, signature: string, key: string): Promise<boolean> {
   // const challengeBuffer = Buffer.from(challenge, 'base64')
   // const signatureBuffer = Buffer.from(signature, 'base64')
 

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -31,7 +31,7 @@ describe('Challenge Generation', (): void => {
 describe('Signature Verification', (): void => {
   // Repeat test with different keys
   for (let index = 0; index < 4; index++) {
-    it('verifies correct signature - EC Key', async (): Promise<void> => {
+    it('verifies correct signature - EC Key', (): void => {
       const keyPair = crypto.generateKeyPairSync('ec', {
         namedCurve: 'secp256k1', // Allowed by FIDO spec
         publicKeyEncoding: {
@@ -51,13 +51,13 @@ describe('Signature Verification', (): void => {
 
       const sign = signer.sign(keyPair.privateKey, 'base64')
 
-      expect(await verifySign(challenge, sign, keyPair.publicKey)).toEqual(true)
+      expect(verifySign(challenge, sign, keyPair.publicKey)).toEqual(true)
     })
   }
 
   // Repeat test with different keys
   for (let index = 0; index < 4; index++) {
-    it('returns false on incorrect signature - wrong EC key', async (): Promise<void> => {
+    it('returns false on incorrect signature - wrong EC key', (): void => {
       const realKeyPair = crypto.generateKeyPairSync('ec', {
         namedCurve: 'secp256k1', // Allowed by FIDO spec
         publicKeyEncoding: {
@@ -89,11 +89,11 @@ describe('Signature Verification', (): void => {
 
       const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
 
-      expect(await verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
+      expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
     })
   }
 
-  it('verifies correct signature - RSA Key', async (): Promise<void> => {
+  it('verifies correct signature - RSA Key', (): void => {
     const realKeyPair = crypto.generateKeyPairSync('rsa', {
       modulusLength: 2048 // Key length in bits
     })
@@ -105,10 +105,10 @@ describe('Signature Verification', (): void => {
 
     const sign = signer.sign(realKeyPair.privateKey, 'base64')
 
-    expect(await verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(true)
+    expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(true)
   })
 
-  it('returns false on incorrect signature - RSA Key', async (): Promise<void> => {
+  it('returns false on incorrect signature - RSA Key', (): void => {
     const fakeKeyPair = crypto.generateKeyPairSync('rsa', {
       modulusLength: 2048 // Key length in bits
     })
@@ -124,10 +124,10 @@ describe('Signature Verification', (): void => {
 
     const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
 
-    expect(await verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
+    expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
   })
 
-  it('returns false on key algorithm mismatch', async (): Promise<void> => {
+  it('returns false on key algorithm mismatch', (): void => {
     const fakeKeyPair = crypto.generateKeyPairSync('rsa', {
       modulusLength: 2048 // Key length in bits
     })
@@ -151,6 +151,6 @@ describe('Signature Verification', (): void => {
 
     const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
 
-    expect(await verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
+    expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
   })
 })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -32,7 +32,7 @@ describe('Challenge Generation', (): void => {
 /*
  * Signature Verification Unit Tests
  *
- * Currently, the tests focus on RSA and ECDSA:secp256k1 keys.
+ * Currently, the tests focus on RSA 2048 and ECDSA:secp256k1 keys.
  * Support for additional keys can be extended further.
  */
 describe('Signature Verification', (): void => {
@@ -42,8 +42,10 @@ describe('Signature Verification', (): void => {
 
   beforeEach((): void => {
     challenge = 'Crypto Auth service Yay!'
+    // Digest Algorithm
     signer = crypto.createSign('SHA256')
 
+    // Hash challenge using SHA256
     signer.update(challenge)
   })
 

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -54,8 +54,9 @@ describe('Signature Verification', (): void => {
     })
 
     const sign = signer.sign(keyPair.privateKey, 'base64')
+    const verified = verifySign(challenge, sign, keyPair.publicKey)
 
-    expect(verifySign(challenge, sign, keyPair.publicKey)).toEqual(true)
+    expect(verified).toEqual(true)
   })
 
   // Using another challenge message
@@ -80,8 +81,9 @@ describe('Signature Verification', (): void => {
     anotherSigner.update(anotherChallenge)
 
     const sign = anotherSigner.sign(keyPair.privateKey, 'base64')
+    const verified = verifySign(anotherChallenge, sign, keyPair.publicKey)
 
-    expect(verifySign(anotherChallenge, sign, keyPair.publicKey)).toEqual(true)
+    expect(verified).toEqual(true)
   })
 
   it('returns false on incorrect signature - wrong EC key', (): void => {
@@ -110,8 +112,9 @@ describe('Signature Verification', (): void => {
     })
 
     const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
+    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
 
-    expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
+    expect(verified).toEqual(false)
   })
 
   it('returns false on incorrect signature - wrong challenge', (): void => {
@@ -147,8 +150,9 @@ describe('Signature Verification', (): void => {
     anotherSigner.update(anotherChallenge)
 
     const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
+    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
 
-    expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
+    expect(verified).toEqual(false)
   })
 
   it('verifies correct signature - RSA Key', (): void => {
@@ -157,8 +161,9 @@ describe('Signature Verification', (): void => {
     })
 
     const sign = signer.sign(realKeyPair.privateKey, 'base64')
+    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
 
-    expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(true)
+    expect(verified).toEqual(true)
   })
 
   it('returns false on incorrect signature - RSA Key', (): void => {
@@ -171,8 +176,9 @@ describe('Signature Verification', (): void => {
     })
 
     const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
+    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
 
-    expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
+    expect(verified).toEqual(false)
   })
 
   it('returns false on key algorithm mismatch', (): void => {
@@ -193,7 +199,8 @@ describe('Signature Verification', (): void => {
     })
 
     const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
+    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
 
-    expect(verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
+    expect(verified).toEqual(false)
   })
 })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -28,6 +28,7 @@ describe('Challenge Generation', (): void => {
   })
 })
 
+// Each test generates a random key pair
 describe('Signature Verification', (): void => {
   let challenge: string
   let signer: crypto.Signer

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto'
 import Logger from '@mojaloop/central-services-logger'
 import Credential from './credential'
-import { generate, verifySign } from '../../../src/lib/challenge'
+import { generate, verifySignature } from '../../../src/lib/challenge'
 
 describe('Challenge Generation', (): void => {
   it('Should return a 32 byte string by default', async (): Promise<void> => {
@@ -63,17 +63,17 @@ describe('Signature Verification', (): void => {
       }
     })
 
-    const sign = signer.sign(keyPair.privateKey, 'base64')
-    const verified = verifySign(challenge, sign, keyPair.publicKey)
+    const signature = signer.sign(keyPair.privateKey, 'base64')
+    const verified = verifySignature(challenge, signature, keyPair.publicKey)
 
     expect(verified).toEqual(true)
   })
 
-  // Using a correct hardcoded key, challenge and sign triplet
+  // Using a correct hardcoded key, challenge and signature triplet
   it('verifies correct signature - hardcoded EC Key (secp256k1)', (): void => {
     const { message, signature, keyPair } = Credential.EC
 
-    const verified = verifySign(message, signature, keyPair.public)
+    const verified = verifySignature(message, signature, keyPair.public)
 
     expect(verified).toEqual(true)
   })
@@ -103,8 +103,8 @@ describe('Signature Verification', (): void => {
       }
     })
 
-    const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
-    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
+    const signature = signer.sign(fakeKeyPair.privateKey, 'base64')
+    const verified = verifySignature(challenge, signature, realKeyPair.publicKey)
 
     expect(verified).toEqual(false)
   })
@@ -141,13 +141,13 @@ describe('Signature Verification', (): void => {
 
     anotherSigner.update(anotherChallenge)
 
-    const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
-    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
+    const signature = signer.sign(fakeKeyPair.privateKey, 'base64')
+    const verified = verifySignature(challenge, signature, realKeyPair.publicKey)
 
     expect(verified).toEqual(false)
   })
 
-  // Using a hardcoded key, challenge and sign triplet
+  // Using a hardcoded key, challenge and signature triplet
   it('returns false for signature based on wrong challenge - hardcoded EC Key (secp256k1)', (): void => {
     const { message, keyPair } = Credential.EC
 
@@ -158,8 +158,8 @@ describe('Signature Verification', (): void => {
 
     anotherSigner.update(anotherChallenge)
 
-    const sign = signer.sign(keyPair.private, 'base64')
-    const verified = verifySign(message, sign, keyPair.public)
+    const signature = signer.sign(keyPair.private, 'base64')
+    const verified = verifySignature(message, signature, keyPair.public)
 
     expect(verified).toEqual(false)
   })
@@ -169,17 +169,17 @@ describe('Signature Verification', (): void => {
       modulusLength: 2048 // Key length in bits
     })
 
-    const sign = signer.sign(realKeyPair.privateKey, 'base64')
-    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
+    const signature = signer.sign(realKeyPair.privateKey, 'base64')
+    const verified = verifySignature(challenge, signature, realKeyPair.publicKey)
 
     expect(verified).toEqual(true)
   })
 
-  // Using a correct hardcoded key, challenge and sign triplet
+  // Using a correct hardcoded key, challenge and signature triplet
   it('verifies correct signature - hardcoded RSA 2048 key', (): void => {
     const { message, signature, keyPair } = Credential.RSA
 
-    const verified = verifySign(message, signature, keyPair.public)
+    const verified = verifySignature(message, signature, keyPair.public)
 
     expect(verified).toEqual(true)
   })
@@ -193,13 +193,13 @@ describe('Signature Verification', (): void => {
       modulusLength: 2048 // Key length in bits
     })
 
-    const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
-    const verified = verifySign(challenge, sign, realKeyPair.publicKey)
+    const signature = signer.sign(fakeKeyPair.privateKey, 'base64')
+    const verified = verifySignature(challenge, signature, realKeyPair.publicKey)
 
     expect(verified).toEqual(false)
   })
 
-  // Using a hardcoded key, challenge and sign triplet
+  // Using a hardcoded key, challenge and signature triplet
   it('returns false for signature based on wrong challenge - hardcoded RSA 2048 key', (): void => {
     const { message, keyPair } = Credential.RSA
 
@@ -210,8 +210,8 @@ describe('Signature Verification', (): void => {
 
     anotherSigner.update(anotherChallenge)
 
-    const sign = signer.sign(keyPair.private, 'base64')
-    const verified = verifySign(message, sign, keyPair.public)
+    const signature = signer.sign(keyPair.private, 'base64')
+    const verified = verifySignature(message, signature, keyPair.public)
 
     expect(verified).toEqual(false)
   })
@@ -235,11 +235,11 @@ describe('Signature Verification', (): void => {
 
     anotherSigner.update(anotherChallenge)
 
-    const sign = signer.sign(keyPair.private, 'base64')
+    const signature = signer.sign(keyPair.private, 'base64')
 
     // Assertions
     expect((): void => {
-      verifySign(message, sign, keyPair.public)
+      verifySignature(message, signature, keyPair.public)
     }).toThrowError('Unable to create Verify in mock')
 
     // Verify that crypto function is called correctly

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -216,7 +216,7 @@ describe('Signature Verification', (): void => {
     expect(verified).toEqual(false)
   })
 
-  it('properly uses crypto functions and handles exceptions', (): void => {
+  it('properly uses crypto.createVerify function and handles exceptions', (): void => {
     const { message, keyPair } = Credential.RSA
 
     // Setting up mocks
@@ -225,6 +225,8 @@ describe('Signature Verification', (): void => {
     })
 
     const loggerPushSpy = jest.spyOn(Logger, 'push')
+    // Mocking `Logger.error` because it indirectly calls
+    // Logger.push and we want to only test usage of Logger's interface
     const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation((): void => {})
 
     // Setting up the signature

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -1,4 +1,5 @@
-import { generate } from '../../../src/lib/challenge'
+import { generate, verify } from '../../../src/lib/challenge'
+import crypto from 'crypto'
 
 describe('Challenge Generation', (): void => {
   it('Should return a 32 byte string by default', async (): Promise<void> => {
@@ -24,5 +25,42 @@ describe('Challenge Generation', (): void => {
   it('Should return a 8 byte string even if negative float point argument passed', async (): Promise<void> => {
     const challenge = await generate(-8.1)
     expect(Buffer.byteLength(challenge, 'base64')).toBe(8)
+  })
+})
+
+describe('Challenge Verification', (): void => {
+  it('Verify challenge', async (): Promise<void> => {
+    const privateKey: string = '-----BEGIN RSA PRIVATE KEY-----\n' +
+      'MIICXQIBAAKBgQDCtTEic76GBqUetJ1XXrrWZcxd8vJr2raWRqBjbGpSzLqa3YLv\n' +
+      'VxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSupolzZrwMFSylxGwR5jPmoNHDM\n' +
+      'S3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPMt4KUcQ1TaazB8TzhqwIDAQAB\n' +
+      'AoGAM8WeBP0lwdluelWoKJ0lrPBwgOKilw8W0aqB5y3ir5WEYL1ZnW5YXivS+l2s\n' +
+      'tNELrEdapSbE9hieNBCvKMViABQXj4DRw5Dgpfz6Hc8XIzoEl68DtxL313EyouZD\n' +
+      'jOiOGWW5UTBatLh05Fa5rh0FbZn8GsHrA6nhz4Fg2zGzpyECQQDi8rN6qhjEk5If\n' +
+      '+fOBT+kjHZ/SLrH6OIeAJ+RYstjOfS0bWiM9Wvrhtr7DZkIUA5JNsmeANUGlCrQ2\n' +
+      'cBJU2cJJAkEA26HyehCmnCkCjit7s8g3MdT0ys5WvrAFO6z3+kCbCAsGS+34EgnF\n' +
+      'yz8dDdfUYP410R5+9Cs/RkYesqindsvEUwJBALCmQVXFeKnqQ99n60ZIMSwILxKn\n' +
+      'Dhm6Tp5Obssryt5PSQD1VGC5pHZ0jGAEBIMXlJWtvCprScFxZ3zIFzy8kyECQQDB\n' +
+      'lUhHVo3DblIWRTVPDNW5Ul5AswW6JSM3qgkXxgHfYPg3zJOuMnbn4cUWAnnq06VT\n' +
+      'oHF9fPDUW9GK3yRbjNaJAkAB2Al6yY0KUhYLtWoEpQ40HlATbhNel2cn5WNs6Y5F\n' +
+      '2hedvWdhS/zLzbtbSlOegp00d2/7IBghAfjAc3DE9DZw\n' +
+      '-----END RSA PRIVATE KEY-----'
+
+    const publicKey: string = '-----BEGIN PUBLIC KEY-----\n' +
+      'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCtTEic76GBqUetJ1XXrrWZcxd\n' +
+      '8vJr2raWRqBjbGpSzLqa3YLvVxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSup\n' +
+      'olzZrwMFSylxGwR5jPmoNHDMS3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPM\n' +
+      't4KUcQ1TaazB8TzhqwIDAQAB\n' +
+      '-----END PUBLIC KEY-----'
+
+    const challenge = 'Crypto Auth service Yay!'
+
+    const signer = crypto.createSign('sha256')
+
+    signer.update(challenge)
+
+    const sign = signer.sign(privateKey, 'base64')
+
+    expect(await verify(challenge, sign, publicKey)).toEqual(true)
   })
 })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -30,73 +30,83 @@ describe('Challenge Generation', (): void => {
 
 describe('Signature Verification', (): void => {
   it('verifies correct signature', async (): Promise<void> => {
-    const privateKey: string = '-----BEGIN RSA PRIVATE KEY-----\n' +
-      'MIICXQIBAAKBgQDCtTEic76GBqUetJ1XXrrWZcxd8vJr2raWRqBjbGpSzLqa3YLv\n' +
-      'VxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSupolzZrwMFSylxGwR5jPmoNHDM\n' +
-      'S3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPMt4KUcQ1TaazB8TzhqwIDAQAB\n' +
-      'AoGAM8WeBP0lwdluelWoKJ0lrPBwgOKilw8W0aqB5y3ir5WEYL1ZnW5YXivS+l2s\n' +
-      'tNELrEdapSbE9hieNBCvKMViABQXj4DRw5Dgpfz6Hc8XIzoEl68DtxL313EyouZD\n' +
-      'jOiOGWW5UTBatLh05Fa5rh0FbZn8GsHrA6nhz4Fg2zGzpyECQQDi8rN6qhjEk5If\n' +
-      '+fOBT+kjHZ/SLrH6OIeAJ+RYstjOfS0bWiM9Wvrhtr7DZkIUA5JNsmeANUGlCrQ2\n' +
-      'cBJU2cJJAkEA26HyehCmnCkCjit7s8g3MdT0ys5WvrAFO6z3+kCbCAsGS+34EgnF\n' +
-      'yz8dDdfUYP410R5+9Cs/RkYesqindsvEUwJBALCmQVXFeKnqQ99n60ZIMSwILxKn\n' +
-      'Dhm6Tp5Obssryt5PSQD1VGC5pHZ0jGAEBIMXlJWtvCprScFxZ3zIFzy8kyECQQDB\n' +
-      'lUhHVo3DblIWRTVPDNW5Ul5AswW6JSM3qgkXxgHfYPg3zJOuMnbn4cUWAnnq06VT\n' +
-      'oHF9fPDUW9GK3yRbjNaJAkAB2Al6yY0KUhYLtWoEpQ40HlATbhNel2cn5WNs6Y5F\n' +
-      '2hedvWdhS/zLzbtbSlOegp00d2/7IBghAfjAc3DE9DZw\n' +
-      '-----END RSA PRIVATE KEY-----'
+    // const privateKey: string = '-----BEGIN RSA PRIVATE KEY-----\n' +
+    //   'MIICXQIBAAKBgQDCtTEic76GBqUetJ1XXrrWZcxd8vJr2raWRqBjbGpSzLqa3YLv\n' +
+    //   'VxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSupolzZrwMFSylxGwR5jPmoNHDM\n' +
+    //   'S3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPMt4KUcQ1TaazB8TzhqwIDAQAB\n' +
+    //   'AoGAM8WeBP0lwdluelWoKJ0lrPBwgOKilw8W0aqB5y3ir5WEYL1ZnW5YXivS+l2s\n' +
+    //   'tNELrEdapSbE9hieNBCvKMViABQXj4DRw5Dgpfz6Hc8XIzoEl68DtxL313EyouZD\n' +
+    //   'jOiOGWW5UTBatLh05Fa5rh0FbZn8GsHrA6nhz4Fg2zGzpyECQQDi8rN6qhjEk5If\n' +
+    //   '+fOBT+kjHZ/SLrH6OIeAJ+RYstjOfS0bWiM9Wvrhtr7DZkIUA5JNsmeANUGlCrQ2\n' +
+    //   'cBJU2cJJAkEA26HyehCmnCkCjit7s8g3MdT0ys5WvrAFO6z3+kCbCAsGS+34EgnF\n' +
+    //   'yz8dDdfUYP410R5+9Cs/RkYesqindsvEUwJBALCmQVXFeKnqQ99n60ZIMSwILxKn\n' +
+    //   'Dhm6Tp5Obssryt5PSQD1VGC5pHZ0jGAEBIMXlJWtvCprScFxZ3zIFzy8kyECQQDB\n' +
+    //   'lUhHVo3DblIWRTVPDNW5Ul5AswW6JSM3qgkXxgHfYPg3zJOuMnbn4cUWAnnq06VT\n' +
+    //   'oHF9fPDUW9GK3yRbjNaJAkAB2Al6yY0KUhYLtWoEpQ40HlATbhNel2cn5WNs6Y5F\n' +
+    //   '2hedvWdhS/zLzbtbSlOegp00d2/7IBghAfjAc3DE9DZw\n' +
+    //   '-----END RSA PRIVATE KEY-----'
 
-    const publicKey: string = '-----BEGIN PUBLIC KEY-----\n' +
-      'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCtTEic76GBqUetJ1XXrrWZcxd\n' +
-      '8vJr2raWRqBjbGpSzLqa3YLvVxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSup\n' +
-      'olzZrwMFSylxGwR5jPmoNHDMS3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPM\n' +
-      't4KUcQ1TaazB8TzhqwIDAQAB\n' +
-      '-----END PUBLIC KEY-----'
+    // const publicKey: string = '-----BEGIN PUBLIC KEY-----\n' +
+    //   'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCtTEic76GBqUetJ1XXrrWZcxd\n' +
+    //   '8vJr2raWRqBjbGpSzLqa3YLvVxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSup\n' +
+    //   'olzZrwMFSylxGwR5jPmoNHDMS3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPM\n' +
+    //   't4KUcQ1TaazB8TzhqwIDAQAB\n' +
+    //   '-----END PUBLIC KEY-----'
+
+    const keyPair = crypto.generateKeyPairSync('ec', {
+      namedCurve: 'secp256k1', // Allowed by FIDO spec
+      publicKeyEncoding: {
+        type: 'spki', // Key infrasructure
+        format: 'pem' // Encoding format
+      },
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem'
+      }
+    })
 
     const challenge = 'Crypto Auth service Yay!'
-
-    const signer = crypto.createSign('sha256')
+    const signer = crypto.createSign('SHA256')
 
     signer.update(challenge)
 
-    const sign = signer.sign(privateKey, 'base64')
+    const sign = signer.sign(keyPair.privateKey, 'base64')
 
-    expect(await verifySign(challenge, sign, publicKey)).toEqual(true)
+    expect(await verifySign(challenge, sign, keyPair.publicKey)).toEqual(true)
   })
 
   it('returns false on incorrect signature', async (): Promise<void> => {
-    // Incorrect private key for signing
-    const privateKey: string = '-----BEGIN RSA PRIVATE KEY-----\n' +
-      'MIICXQIBAAKBgQDCtTEic76GBqUetJ1XXrrWZcxd8vJr2raWRqBjbGpSzLqa3YLv\n' +
-      'VxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSupolzZrwMFSylxGwR5jPmoNHDM\n' +
-      'S3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPMt4KUcQ1TaazB8TzhqwIDAQAB\n' +
-      'AoGAM8WeBP0lwdluelWoKJ0lrPBwgOKilw8W0aqB5y3ir5WEYL1ZnW5YXivS+l2s\n' +
-      'tNELrEdapSbE9hieNBCvKMViABQXj4DRw5Dgww3lec8XIzoEl68DtxL313EyouZD\n' +
-      'jOiOGWW5UTBatLh05Fa5rh0FbZn8GsHwA6nhz4Fg2zGzpyECQQDi8rN6qhjEk5If\n' +
-      '+fOBT+kjHZ/SLrH6OIeAJ+RYstjOfSewbWiM9Wvrhr7DZkIUA5JNsmeANUGlCrQ2\n' +
-      'cBJU2cJJAkEA26HyehCmnCkCjit73E33MdT0ys5WvrAFO6z3+kCbCAsGS+34EgnF\n' +
-      'yz8dDdfUYP410R5+9Cs/RkYesqindsvEUwJBALCmQVXFeKnqQ99n60ZIMSwILxKn\n' +
-      'Dhm6Tp5Obssryt5PSQD1VGC5pHZ0jGAEBIMXlJWtvCprScFxZ3zIFzy8kyECQQDB\n' +
-      'lUhHVo3DblIWRTVPDNW5Ul5AswW6JSM3qgkXxgHfYPg3zJOuMnbn4cUWAnnq06VT\n' +
-      'oHF9fPDUW9GK3yRbjNaJAkAB2Al6yY0KUhYLtWoEpQ40HlATbhNel2cn5WNs6Y5F\n' +
-      '2hedvWdhS/zLzbtbSlOegp00d2/7IBghAfjAc3DE94R2\n' +
-      '-----END RSA PRIVATE KEY-----'
+    const realKeyPair = crypto.generateKeyPairSync('ec', {
+      namedCurve: 'secp256k1', // Allowed by FIDO spec
+      publicKeyEncoding: {
+        type: 'spki', // Key infrasructure
+        format: 'pem' // Encoding format
+      },
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem'
+      }
+    })
 
-    const publicKey: string = '-----BEGIN PUBLIC KEY-----\n' +
-      'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCtTEic76GBqUetJ1XXrrWZcxd\n' +
-      '8vJr2raWRqBjbGpSzLqa3YLvVxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSup\n' +
-      'olzZrwMFSylxGwR5jPmoNHDMS3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPM\n' +
-      't4KUcQ1TaazB8TzhqwIDAQAB\n' +
-      '-----END PUBLIC KEY-----'
+    const fakeKeyPair = crypto.generateKeyPairSync('ec', {
+      namedCurve: 'secp256k1', // Allowed by FIDO spec
+      publicKeyEncoding: {
+        type: 'spki', // Key infrasructure
+        format: 'pem' // Encoding format
+      },
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem'
+      }
+    })
 
     const challenge = 'Crypto Auth service Yay!'
-
-    const signer = crypto.createSign('sha256')
+    const signer = crypto.createSign('SHA256')
 
     signer.update(challenge)
 
-    const sign = signer.sign(privateKey, 'base64')
+    const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
 
-    expect(await verifySign(challenge, sign, publicKey)).toEqual(false)
+    expect(await verifySign(challenge, sign, realKeyPair.publicKey)).toEqual(false)
   })
 })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -1,4 +1,4 @@
-import { generate, verify } from '../../../src/lib/challenge'
+import { generate, verifySign } from '../../../src/lib/challenge'
 import crypto from 'crypto'
 
 describe('Challenge Generation', (): void => {
@@ -28,8 +28,8 @@ describe('Challenge Generation', (): void => {
   })
 })
 
-describe('Challenge Verification', (): void => {
-  it('Verify challenge', async (): Promise<void> => {
+describe('Signature Verification', (): void => {
+  it('verifies correct signature', async (): Promise<void> => {
     const privateKey: string = '-----BEGIN RSA PRIVATE KEY-----\n' +
       'MIICXQIBAAKBgQDCtTEic76GBqUetJ1XXrrWZcxd8vJr2raWRqBjbGpSzLqa3YLv\n' +
       'VxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSupolzZrwMFSylxGwR5jPmoNHDM\n' +
@@ -61,6 +61,42 @@ describe('Challenge Verification', (): void => {
 
     const sign = signer.sign(privateKey, 'base64')
 
-    expect(await verify(challenge, sign, publicKey)).toEqual(true)
+    expect(await verifySign(challenge, sign, publicKey)).toEqual(true)
+  })
+
+  it('returns false on incorrect signature', async (): Promise<void> => {
+    // Incorrect private key for signing
+    const privateKey: string = '-----BEGIN RSA PRIVATE KEY-----\n' +
+      'MIICXQIBAAKBgQDCtTEic76GBqUetJ1XXrrWZcxd8vJr2raWRqBjbGpSzLqa3YLv\n' +
+      'VxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSupolzZrwMFSylxGwR5jPmoNHDM\n' +
+      'S3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPMt4KUcQ1TaazB8TzhqwIDAQAB\n' +
+      'AoGAM8WeBP0lwdluelWoKJ0lrPBwgOKilw8W0aqB5y3ir5WEYL1ZnW5YXivS+l2s\n' +
+      'tNELrEdapSbE9hieNBCvKMViABQXj4DRw5Dgww3lec8XIzoEl68DtxL313EyouZD\n' +
+      'jOiOGWW5UTBatLh05Fa5rh0FbZn8GsHwA6nhz4Fg2zGzpyECQQDi8rN6qhjEk5If\n' +
+      '+fOBT+kjHZ/SLrH6OIeAJ+RYstjOfSewbWiM9Wvrhr7DZkIUA5JNsmeANUGlCrQ2\n' +
+      'cBJU2cJJAkEA26HyehCmnCkCjit73E33MdT0ys5WvrAFO6z3+kCbCAsGS+34EgnF\n' +
+      'yz8dDdfUYP410R5+9Cs/RkYesqindsvEUwJBALCmQVXFeKnqQ99n60ZIMSwILxKn\n' +
+      'Dhm6Tp5Obssryt5PSQD1VGC5pHZ0jGAEBIMXlJWtvCprScFxZ3zIFzy8kyECQQDB\n' +
+      'lUhHVo3DblIWRTVPDNW5Ul5AswW6JSM3qgkXxgHfYPg3zJOuMnbn4cUWAnnq06VT\n' +
+      'oHF9fPDUW9GK3yRbjNaJAkAB2Al6yY0KUhYLtWoEpQ40HlATbhNel2cn5WNs6Y5F\n' +
+      '2hedvWdhS/zLzbtbSlOegp00d2/7IBghAfjAc3DE94R2\n' +
+      '-----END RSA PRIVATE KEY-----'
+
+    const publicKey: string = '-----BEGIN PUBLIC KEY-----\n' +
+      'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDCtTEic76GBqUetJ1XXrrWZcxd\n' +
+      '8vJr2raWRqBjbGpSzLqa3YLvVxVeK49iSlI+5uLX/2WFJdhKAWoqO+03oH4TDSup\n' +
+      'olzZrwMFSylxGwR5jPmoNHDMS3nnzUkBtdr3NCfq1C34fQV0iUGdlPtJaiiTBQPM\n' +
+      't4KUcQ1TaazB8TzhqwIDAQAB\n' +
+      '-----END PUBLIC KEY-----'
+
+    const challenge = 'Crypto Auth service Yay!'
+
+    const signer = crypto.createSign('sha256')
+
+    signer.update(challenge)
+
+    const sign = signer.sign(privateKey, 'base64')
+
+    expect(await verifySign(challenge, sign, publicKey)).toEqual(false)
   })
 })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -1,5 +1,6 @@
-import { generate, verifySign } from '../../../src/lib/challenge'
 import crypto from 'crypto'
+import Credential from './credential'
+import { generate, verifySign } from '../../../src/lib/challenge'
 
 describe('Challenge Generation', (): void => {
   it('Should return a 32 byte string by default', async (): Promise<void> => {
@@ -28,8 +29,14 @@ describe('Challenge Generation', (): void => {
   })
 })
 
-// Each test generates a random key pair
+/*
+ * Signature Verification Unit Tests
+ *
+ * Currently, the tests focus on RSA and ECDSA:secp256k1 keys.
+ * Support for additional keys can be extended further.
+ */
 describe('Signature Verification', (): void => {
+  // Each test generates a random key pair
   let challenge: string
   let signer: crypto.Signer
 
@@ -40,7 +47,7 @@ describe('Signature Verification', (): void => {
     signer.update(challenge)
   })
 
-  it('verifies correct signature - EC Key', (): void => {
+  it('verifies correct signature - EC Key (secp256k1)', (): void => {
     const keyPair = crypto.generateKeyPairSync('ec', {
       namedCurve: 'secp256k1', // Allowed by FIDO spec
       publicKeyEncoding: {
@@ -59,34 +66,16 @@ describe('Signature Verification', (): void => {
     expect(verified).toEqual(true)
   })
 
-  // Using another challenge message
-  it('verifies correct signature - EC Key', (): void => {
-    const keyPair = crypto.generateKeyPairSync('ec', {
-      namedCurve: 'secp256k1', // Allowed by FIDO spec
-      publicKeyEncoding: {
-        type: 'spki', // Key infrasructure
-        format: 'pem' // Encoding format
-      },
-      privateKeyEncoding: {
-        type: 'pkcs8',
-        format: 'pem'
-      }
-    })
+  // Using a correct hardcoded key, challenge and sign triplet
+  it('verifies correct signature - hardcoded EC Key (secp256k1)', (): void => {
+    const { message, signature, keyPair } = Credential.EC
 
-    // Need another Sign object instead of updating the outer one
-    // because of parallel test runs
-    const anotherChallenge = 'This is a different message'
-    const anotherSigner = crypto.createSign('SHA256')
-
-    anotherSigner.update(anotherChallenge)
-
-    const sign = anotherSigner.sign(keyPair.privateKey, 'base64')
-    const verified = verifySign(anotherChallenge, sign, keyPair.publicKey)
+    const verified = verifySign(message, signature, keyPair.public)
 
     expect(verified).toEqual(true)
   })
 
-  it('returns false on incorrect signature - wrong EC key', (): void => {
+  it('returns false on signature with wrong key - EC Key (secp256k1)', (): void => {
     const realKeyPair = crypto.generateKeyPairSync('ec', {
       namedCurve: 'secp256k1', // Allowed by FIDO spec
       publicKeyEncoding: {
@@ -117,7 +106,7 @@ describe('Signature Verification', (): void => {
     expect(verified).toEqual(false)
   })
 
-  it('returns false on incorrect signature - wrong challenge', (): void => {
+  it('returns false for signature based on wrong challenge - EC Key (secp256k1)', (): void => {
     const realKeyPair = crypto.generateKeyPairSync('ec', {
       namedCurve: 'secp256k1', // Allowed by FIDO spec
       publicKeyEncoding: {
@@ -151,6 +140,21 @@ describe('Signature Verification', (): void => {
 
     const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
     const verified = verifySign(challenge, sign, realKeyPair.publicKey)
+
+    expect(verified).toEqual(false)
+  })
+
+  // Using a hardcoded key, challenge and sign triplet
+  it('returns false for signature based on wrong challenge - hardcoded EC Key (secp256k1)', (): void => {
+    const { message, keyPair } = Credential.EC
+
+    const anotherChallenge = 'This is a different message'
+    const anotherSigner = crypto.createSign('SHA256')
+
+    anotherSigner.update(anotherChallenge)
+
+    const sign = signer.sign(keyPair.private, 'base64')
+    const verified = verifySign(message, sign, keyPair.public)
 
     expect(verified).toEqual(false)
   })

--- a/test/unit/lib/challenge.test.ts
+++ b/test/unit/lib/challenge.test.ts
@@ -161,7 +161,7 @@ describe('Signature Verification', (): void => {
     expect(verified).toEqual(false)
   })
 
-  it('verifies correct signature - RSA Key', (): void => {
+  it('verifies correct signature - RSA 2048 Key', (): void => {
     const realKeyPair = crypto.generateKeyPairSync('rsa', {
       modulusLength: 2048 // Key length in bits
     })
@@ -172,7 +172,16 @@ describe('Signature Verification', (): void => {
     expect(verified).toEqual(true)
   })
 
-  it('returns false on incorrect signature - RSA Key', (): void => {
+  // Using a correct hardcoded key, challenge and sign triplet
+  it('verifies correct signature - hardcoded RSA 2048 key', (): void => {
+    const { message, signature, keyPair } = Credential.RSA
+
+    const verified = verifySign(message, signature, keyPair.public)
+
+    expect(verified).toEqual(true)
+  })
+
+  it('returns false on signature based on wrong key - RSA 2048 Key', (): void => {
     const fakeKeyPair = crypto.generateKeyPairSync('rsa', {
       modulusLength: 2048 // Key length in bits
     })
@@ -183,6 +192,21 @@ describe('Signature Verification', (): void => {
 
     const sign = signer.sign(fakeKeyPair.privateKey, 'base64')
     const verified = verifySign(challenge, sign, realKeyPair.publicKey)
+
+    expect(verified).toEqual(false)
+  })
+
+  // Using a hardcoded key, challenge and sign triplet
+  it('returns false for signature based on wrong challenge - hardcoded RSA 2048 key', (): void => {
+    const { message, keyPair } = Credential.RSA
+
+    const anotherChallenge = 'This is a different message'
+    const anotherSigner = crypto.createSign('SHA256')
+
+    anotherSigner.update(anotherChallenge)
+
+    const sign = signer.sign(keyPair.private, 'base64')
+    const verified = verifySign(message, sign, keyPair.public)
 
     expect(verified).toEqual(false)
   })

--- a/test/unit/lib/credential.ts
+++ b/test/unit/lib/credential.ts
@@ -20,6 +20,56 @@ const Credential = {
       'xTaSoD9Ef9IfovmPzHqXtuGi5j8oY9IHQq9U',
     // UTF-8 original message
     message: 'Hello I am trying to test this!'
+  },
+  RSA: {
+    // RSA 2048 openSSL key pair in pem (base64) format
+    keyPair: {
+      public: '-----BEGIN PUBLIC KEY-----\n' +
+        'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoMUEWn+F1nocD5EJBk4N\n' +
+        'vk1oGtAr6yFN7e7vlPWEJ2fY7dB/YtXMi5bjZcUhWj9Qoc+mqa38vL4q8hpZTkR1\n' +
+        'JQ443bFAJz090sSeG5jT657C8+WpWCQvx97gtl+lh3gEG5312LjVkGqQmVFjRKlj\n' +
+        'vOoHEij0AEcRtc4DjV+PHIsV1kQicYvN8zOYO4oWy9LM7XVcg4ciFWT/q4FT+mrB\n' +
+        '9ho22bt1QOP7x2Q5L3fsFp0NB/WD3973v318jUO79oNyxO4apR2NS/6hHjUsItwO\n' +
+        'rK26NyG9PPy6jl0huQ2UM8APIvZAulqHh5M6gptNV0s9l9smd5LJK87GERARrIqw\n' +
+        'QwIDAQAB\n' +
+        '-----END PUBLIC KEY-----',
+      private: '-----BEGIN RSA PRIVATE KEY-----\n' +
+        'MIIEowIBAAKCAQEAoMUEWn+F1nocD5EJBk4Nvk1oGtAr6yFN7e7vlPWEJ2fY7dB/\n' +
+        'YtXMi5bjZcUhWj9Qoc+mqa38vL4q8hpZTkR1JQ443bFAJz090sSeG5jT657C8+Wp\n' +
+        'WCQvx97gtl+lh3gEG5312LjVkGqQmVFjRKljvOoHEij0AEcRtc4DjV+PHIsV1kQi\n' +
+        'cYvN8zOYO4oWy9LM7XVcg4ciFWT/q4FT+mrB9ho22bt1QOP7x2Q5L3fsFp0NB/WD\n' +
+        '3973v318jUO79oNyxO4apR2NS/6hHjUsItwOrK26NyG9PPy6jl0huQ2UM8APIvZA\n' +
+        'ulqHh5M6gptNV0s9l9smd5LJK87GERARrIqwQwIDAQABAoIBAB/aiV9I7wKs1Qx8\n' +
+        'hxY5tt1ixuKxJlKDGcav1cZk0tdf6wpLikHR7KIntkx+v3n7G4XD99icwXvADhBE\n' +
+        'CjfItpEt/TRnnzdnGe29yTnckPiZTzU15tSw7sqiLVHVJ53suJukM4bKMH5ZrubB\n' +
+        'ynJbQYi3scj2VkoLysWD2Q5Uxa04zRQdhsd84G1UmPYSKWE4/1PyCDEi9kFlgOFn\n' +
+        'vMLetq1BD3e8h9zUAXWG68cQjE8acQslDleY86YwcKby94lDzdBq14dvAN8vbfm9\n' +
+        'k0scPFye2MGOi33++9dIcPtv27J2sEf/0t6wgba1oDWoqe14rn8RmlsCnudSTirl\n' +
+        'krMFyaECgYEA1FDgotTC1+ALJWjqS3+MRw4Q2NbHsn9DF1I4X1ABt496hzE1zh8w\n' +
+        '2DVynTH3lhqGFew/Zn6FldujK2u/B+K12phd2Q2oBD+7zCDA7PWVLsI84N46wfgh\n' +
+        'hf24SaPML0tniDWAlXr41OigFCTOTbEQpryew0cc/RgoRVGdyxOkGtMCgYEAwdkW\n' +
+        'PL0a0d+4j1FKf3ddeumE4j6d0GFcKP8JeE+S3X2Y1K/qTl4M1jepOrdoagWoC6PI\n' +
+        'YYrDwozZN0vpyuwrTGyp9ziUbD2P/llQvULGikG3GyXu07/UU/dBVkMEabEn4BXQ\n' +
+        'dZfBvdWh9wFW8/mwvgPyDac+a1YL7V+yCs85ztECgYBbqYcyBXURSjLFtePhMHHZ\n' +
+        'g2MWmrOghnzqpp6b16jGHPWjREWcda7ayUhwQVBIx6637ET69QirSCXL6zqQJvqo\n' +
+        'IzvxJ4owO2vSlxlztBryEv3Bf3ASqhOfC4jykfrnOEC8d4zJ/EtNcBkcWT+QHy+3\n' +
+        'LJvGZv9G7ZUFSFU9hX9F7QKBgE+oWLX+86145MuoGRgGQhjHKz8ZghpmV8vU+dxB\n' +
+        'vtVbzljgLUWk6luBJf6l7bdbubGGzUogDs+8t2o8vMcRg711Dec0jfFo3uojY8VS\n' +
+        'UmnwFUGHtfu34ZXbjjLXeVHBZeR0smQQR6Itzs/E8ilx2spKrsYjisfq5R3XbD96\n' +
+        '5oNxAoGBAM3p1Tl7riOUIGIxUZldl0hFwjwOyNG7fyi0o1snvc8Fl54TivdZAWvw\n' +
+        '4p79zhATYymeUbHit4D6nsoYiBUBaJg4DWjnUkFUQWxer2AsfQ5tDD2TAAASPour\n' +
+        'GxfwNd6UUugoYVhj8V3JG6ws42tMDd021o6tPWaHaQmfyaDYYytA\n' +
+        '-----END RSA PRIVATE KEY-----'
+    },
+    // Base64 sign digested through SHA256 and signed using private key
+    signature: 'dhX6AGncg6kxnXAwsZlBotrqjDsHVAm9Fz8NaAwdwDkfhDNDJY9nXhTMQcDclM74' +
+      'Vpib9yhLDj4UkGG3dZv0gC67fPSOGtjQkgn0NdbJ066g+TBJfPhdR2RB9nh02kgC' +
+      'W1PQ5MWmszN0QC1aG/emOqqfFHsAqkl2n7aSgIhgyHVSVTU5sPLohvw16hmlJ4s+' +
+      '9pzT8xvS7me8b949hmBokSwOSPMteUcR/L6WtxRvNDAnwM9EJw4UR7Tr9wdNPi59' +
+      '+w3olM+nImRKNYoPY6HQEK1UHtusNO73ktCN4hUZrGVopTH/PFOurWqlL1y1v3di' +
+      '9vhI95vi8l45Z9k4sYo78A==',
+    // UTF-8 original message
+    message: 'Hello I am trying to test this!'
   }
 }
 

--- a/test/unit/lib/credential.ts
+++ b/test/unit/lib/credential.ts
@@ -1,0 +1,26 @@
+/*
+ * Manually generated openSSL credentials
+ */
+const Credential = {
+  EC: {
+    // Secp256k1 openSSL key pair in pem (base64) format
+    keyPair: {
+      public: '-----BEGIN PUBLIC KEY-----\n' +
+        'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgAxzw4HxmDWmxJ8dWuzV/DR6+N1diG3U\n' +
+        'rPwJWdQbUAvDtQ+mRKPl8lD6WrN6PajHwxyeBE77QyOrOCGWn16xzQ==\n' +
+        '-----END PUBLIC KEY-----',
+      private: '-----BEGIN EC PRIVATE KEY-----\n' +
+        'MHQCAQEEIFFd2lZMG6GtgjrLANA721fVAmgzP4lRZqVFI5OOf/zaoAcGBSuBBAAK\n' +
+        'oUQDQgAEgAxzw4HxmDWmxJ8dWuzV/DR6+N1diG3UrPwJWdQbUAvDtQ+mRKPl8lD6\n' +
+        'WrN6PajHwxyeBE77QyOrOCGWn16xzQ==\n' +
+        '-----END EC PRIVATE KEY-----'
+    },
+    // Base64 sign digested through SHA256 and signed using private key
+    signature: 'MEYCIQC7d3TECMWdWU2bgoUWBv4q6XoOUtRZE5Fgom+seTqT/QIhAK6r3UG+' +
+      'xTaSoD9Ef9IfovmPzHqXtuGi5j8oY9IHQq9U',
+    // UTF-8 original message
+    message: 'Hello I am trying to test this!'
+  }
+}
+
+export default Credential


### PR DESCRIPTION
In reference to ticket number #342.

This is a small PR that adds a function to verify incoming digital signatures.
 - Allows RSA and Elliptic keys signature verification
 - Uses SHA256 for hashing the signature
 - Tested on RSA 2048 and EC secp256k1 keys

Related future work will be addressed in following ticket:
 - `#354` End-to-end BDD Testing for Auth-Service Endpoints

Main Work Files:
 - `src/lib/challenge.ts`
 - `test/unit/lib/challenge.test.ts`