### PR TITLE
Fix/341: Modify Consent Insert model return type and improve unit tests for return types

### DIFF
--- a/src/model/consent/consent.ts
+++ b/src/model/consent/consent.ts
@@ -38,8 +38,8 @@
 /*
  * Unlike MySQL, SQLite (testing DB) doesn't support Timestamp type natively.
  * It returns ISO strings using the inbuilt Date() function.
- * Thus, typecasting of MySQL Timestamp to Date object for insertion/retrieval
- * for 'createdAt' field and testing for the same may be required in future.
+ * Thus, return value for MySQL Timestamp as Date object for insertion/retrieval
+ * of 'createdAt' field may need to be tested in the future.
  */
 
 import { NotFoundError } from '../errors'
@@ -73,13 +73,13 @@ export class ConsentDB {
 
   // Add initial Consent parameters
   // Error bubbles up in case of primary key violation
-  public async register (consent: Consent): Promise<number> {
-    // Returns array containing number of inserted rows
-    const insertCount: number[] = await this
+  public async insert (consent: Consent): Promise<boolean> {
+    // Returns [0] for MySQL-Knex and [Row Count] for SQLite-Knex
+    await this
       .Db<Consent>('Consent')
       .insert(consent)
 
-    return insertCount[0]
+    return true
   }
 
   // Update Consent

--- a/test/unit/model/consent.test.ts
+++ b/test/unit/model/consent.test.ts
@@ -38,6 +38,7 @@
 import Knex from 'knex'
 import Config from '../../../config/knexfile'
 import ConsentDB, { Consent } from '../../../src/model/consent'
+import { NotFoundError } from '../../../src/model/errors'
 
 /*
  * Mock Consent Resources
@@ -158,7 +159,9 @@ describe('src/model/consent', (): void => {
         .insert(partialConsent)
 
       // Action
-      await consentDB.update(completeConsent)
+      const updateCount: number = await consentDB.update(completeConsent)
+
+      expect(updateCount).toEqual(1)
 
       // Assertion
       const consents: Consent[] = await Db<Consent>('Consent')
@@ -175,7 +178,7 @@ describe('src/model/consent', (): void => {
     it('throws an error for a non-existent consent', async (): Promise<void> => {
       // Action
       await expect(consentDB.update(completeConsent))
-        .rejects.toThrowError('NotFoundError: Consent for ConsentId 1234')
+        .rejects.toThrowError(NotFoundError)
     })
   })
 
@@ -196,7 +199,7 @@ describe('src/model/consent', (): void => {
     it('throws an error for a non-existent consent', async (): Promise<void> => {
       // Action
       await expect(consentDB.retrieve(completeConsent.id))
-        .rejects.toThrowError('NotFoundError: Consent for ConsentId 1234')
+        .rejects.toThrowError(NotFoundError)
     })
   })
 
@@ -216,7 +219,9 @@ describe('src/model/consent', (): void => {
       expect(consents.length).toEqual(1)
 
       // Action
-      await consentDB.delete(completeConsent.id)
+      const deleteCount: number = await consentDB.delete(completeConsent.id)
+
+      expect(deleteCount).toEqual(1)
 
       // Assertion
       consents = await Db<Consent>('Consent')
@@ -231,7 +236,7 @@ describe('src/model/consent', (): void => {
     it('throws an error for a non-existent consent', async (): Promise<void> => {
       // Action
       await expect(consentDB.delete(completeConsent.id))
-        .rejects.toThrowError('NotFoundError: Consent for ConsentId 1234')
+        .rejects.toThrowError(NotFoundError)
     })
 
     it('deletes associated scopes on deleting a consent', async (): Promise<void> => {
@@ -261,7 +266,9 @@ describe('src/model/consent', (): void => {
       expect(scopes.length).toEqual(2)
 
       // Action
-      await consentDB.delete(completeConsent.id)
+      const deleteCount: number = await consentDB.delete(completeConsent.id)
+
+      expect(deleteCount).toEqual(1)
 
       scopes = await Db('Scope')
         .select('*')

--- a/test/unit/model/consent.test.ts
+++ b/test/unit/model/consent.test.ts
@@ -83,12 +83,12 @@ describe('src/model/consent', (): void => {
     await Db<Consent>('Consent').del()
   })
 
-  describe('register', (): void => {
+  describe('insert', (): void => {
     it('adds consent with partial info to the database', async (): Promise<void> => {
       // Action
-      const numInserted: number = await consentDB.register(partialConsent)
+      const inserted: boolean = await consentDB.insert(partialConsent)
 
-      expect(numInserted).toEqual(1)
+      expect(inserted).toEqual(true)
 
       // Assertion
       const consents: Consent[] = await Db<Consent>('Consent')
@@ -110,9 +110,11 @@ describe('src/model/consent', (): void => {
       })
     })
 
-    it('returns an error on adding a consent with existing consentId', async (): Promise<void> => {
+    it('throws an error on adding a consent with existing consentId', async (): Promise<void> => {
       // Action
-      await consentDB.register(partialConsent)
+      const inserted: boolean = await consentDB.insert(partialConsent)
+
+      expect(inserted).toEqual(true)
 
       // Assertion
       const consents: Consent[] = await Db<Consent>('Consent')
@@ -135,8 +137,17 @@ describe('src/model/consent', (): void => {
       })
 
       // Fail primary key constraint
-      await expect(consentDB.register(partialConsent))
-        .rejects.toThrowError()
+      await expect(consentDB.insert(partialConsent))
+        .rejects.toThrow()
+    })
+
+    it('throws an error on adding consent without an id', async (): Promise<void> => {
+      // Action
+      await expect(consentDB.insert({
+        id: null as unknown as string,
+        initiatorId: '494949',
+        participantId: '3030303'
+      })).rejects.toThrow()
     })
   })
 


### PR DESCRIPTION
In reference to ticket number #341 .

This is a small PR that fixes Consent models.
 - Fixes Insert model return type to match MySQL's
 - Improves unit tests to check for model return types

Main Work Files:
 - `src/model/scope/consent.ts`
 - `test/unit/model/consent.test.ts`