### PR TITLE
Update/341: Modify Consent update model to validate against changing existing data

### DIFF
--- a/src/model/consent/consent.ts
+++ b/src/model/consent/consent.ts
@@ -102,12 +102,13 @@ export class ConsentDB {
       const existingConsent = consents[0]
       const updatedConsent: Consent = { ...consent }
 
-      // Cannot update fields once they have been added properly to the DB
+      // Prepare a new Consent with only allowable updates
+      // * Cannot update Non-NULL fields in the DB
+      // * Field credentialStatus can be updated even
+      //   if when it is NON-NULL but not 'ACTIVE
       for (const key in consent) {
-        // Only include the fields which are NULL in the DB
-        // Include credentialStatus even if NON-NULL but ensure that it is not 'ACTIVE'
         if ((existingConsent[key as keyof Consent] !== null && key !== 'credentialStatus') ||
-            (key === 'credentialStatus' && existingConsent[key as keyof Consent] === 'ACTIVE')) {
+            (key === 'credentialStatus' && existingConsent.credentialStatus === 'ACTIVE')) {
           delete updatedConsent[key as keyof Consent]
         }
       }

--- a/src/model/consent/consent.ts
+++ b/src/model/consent/consent.ts
@@ -124,7 +124,6 @@ export class ConsentDB {
         return 0
       }
 
-      console.log(updatedConsent)
       return trx<Consent>('Consent')
         .where({ id: consent.id })
         .update(updatedConsent)

--- a/test/unit/model/consent.test.ts
+++ b/test/unit/model/consent.test.ts
@@ -227,7 +227,7 @@ describe('src/model/consent', (): void => {
       }))
     })
 
-    it('updates credentialStatus if it is not NULL but also not ACTIVE', async (): Promise<void> => {
+    it('updates credentialStatus if it is not null but also not ACTIVE', async (): Promise<void> => {
       // Inserting record to update
       await Db<Consent>('Consent')
         .insert(completeConsent)

--- a/test/unit/model/consent.test.ts
+++ b/test/unit/model/consent.test.ts
@@ -213,17 +213,18 @@ describe('src/model/consent', (): void => {
           id: completeConsent.id
         })
 
-      expect(consents[0].createdAt).toEqual(expect.any(String))
-
-      // Conflicting fields (initiatorId and participantId) are still the same
-      expect(consents[0]).toEqual(expect.objectContaining(partialConsent))
-
-      // Rest of the fields are updated
-      expect(consents[0].credentialStatus).toEqual(conflictingConsent.credentialStatus)
-      expect(consents[0].credentialType).toEqual(conflictingConsent.credentialType)
-      expect(consents[0].credentialPayload).toEqual(conflictingConsent.credentialPayload)
-      expect(consents[0].credentialId).toEqual(conflictingConsent.credentialId)
-      expect(consents[0].credentialChallenge).toEqual(conflictingConsent.credentialChallenge)
+      expect(consents[0]).toEqual(expect.objectContaining({
+        // Conflicting fields (initiatorId and participantId) are still the same
+        ...partialConsent,
+        // SQLite string date type
+        createdAt: expect.any(String),
+        // Rest of the fields are updated
+        credentialId: conflictingConsent.credentialId,
+        credentialStatus: conflictingConsent.credentialStatus,
+        credentialType: conflictingConsent.credentialType,
+        credentialPayload: conflictingConsent.credentialPayload,
+        credentialChallenge: conflictingConsent.credentialChallenge
+      }))
     })
 
     it('updates credentialStatus if it is not NULL but also not ACTIVE', async (): Promise<void> => {
@@ -243,21 +244,13 @@ describe('src/model/consent', (): void => {
           id: completeConsent.id
         })
 
-      expect(consents[0].createdAt).toEqual(expect.any(String))
-
-      // Conflicting fields (initiatorId and participantId) are still the same
-      expect(consents[0].initiatorId).toEqual(completeConsent.initiatorId)
-      expect(consents[0].participantId).toEqual(completeConsent.participantId)
-
-      // Even other fields are still the same
-      expect(consents[0].id).toEqual(completeConsent.id)
-      expect(consents[0].credentialType).toEqual(completeConsent.credentialType)
-      expect(consents[0].credentialPayload).toEqual(completeConsent.credentialPayload)
-      expect(consents[0].credentialId).toEqual(completeConsent.credentialId)
-      expect(consents[0].credentialChallenge).toEqual(completeConsent.credentialChallenge)
-
-      // credentialStatus is updated to 'ACTIVE'
-      expect(consents[0].credentialStatus).toEqual('ACTIVE')
+      expect(consents[0]).toEqual(expect.objectContaining({
+        // Conflicting fields (initiatorId and participantId) are still the same
+        // Even other fields are the same
+        ...completeConsent,
+        // credentialStatus is updated to 'ACTIVE'
+        credentialStatus: 'ACTIVE'
+      }))
     })
 
     it('throws an error for a non-existent consent', async (): Promise<void> => {

--- a/test/unit/model/consent.test.ts
+++ b/test/unit/model/consent.test.ts
@@ -72,6 +72,7 @@ const consentWithOnlyUpdateFields: Consent = {
 const conflictingConsent: Consent = {
   id: '1234',
   // Conflicting initiatorId and participantId
+  // between completeConsent and this Consent
   initiatorId: 'pisp-0000-1133',
   participantId: 'dfs-1233-5623',
   credentialId: '123',
@@ -196,6 +197,9 @@ describe('src/model/consent', (): void => {
       expect(consents[0]).toEqual(expect.objectContaining(consentWithOnlyUpdateFields))
     })
 
+    // Non conflicting fields imply
+    // * credentialStatus is not `ACTIVE` or
+    // * field is null
     it('updates existing consent with only non-conflicting fields from a consent', async (): Promise<void> => {
       // Inserting record to update
       await Db<Consent>('Consent')


### PR DESCRIPTION
In reference to ticket number #341 .

This modifies `Consent` update model with a transaction for the following:
 - Adds validation against updating an existing field for a record
 - Allows `NON-NULL` `credentialStatus` to be updated if it is not `ACTIVE`
 - Adds unit tests to test the same

Main Work Files:
 - `src/model/scope/consent.ts`
 - `test/unit/model/consent.test.ts`