### PR TITLE
Feature/368: Add Database Model Integration Tests

### DIFF
--- a/test/integration/model/consent.test.ts
+++ b/test/integration/model/consent.test.ts
@@ -30,6 +30,7 @@
 import Knex from 'knex'
 import Config from '../../../config/knexfile'
 import ConsentDB, { Consent } from '../../../src/model/consent'
+import { Scope } from '../../../src/model/scope'
 import { NotFoundError } from '../../../src/model/errors'
 
 /*
@@ -320,9 +321,9 @@ describe('src/model/consent', (): void => {
 
         await Db<Consent>('Consent').insert(completeConsent)
         // Insert associated scopes
-        await Db('Scope').insert(tempScopes)
+        await Db<Scope>('Scope').insert(tempScopes)
 
-        let scopes = await Db('Scope')
+        let scopes = await Db<Scope>('Scope')
           .select('*')
           .where({
             consentId: completeConsent.id
@@ -334,7 +335,7 @@ describe('src/model/consent', (): void => {
 
         expect(deleteCount).toEqual(1)
 
-        scopes = await Db('Scope')
+        scopes = await Db<Scope>('Scope')
           .select('*')
           .where({
             consentId: completeConsent.id

--- a/test/integration/model/consent.test.ts
+++ b/test/integration/model/consent.test.ts
@@ -53,6 +53,7 @@ const completeConsent: Consent = {
   credentialPayload: 'dwuduwd&e2idjoj0w'
 }
 
+// Intentional lack of initiatorId and participantId
 const consentWithOnlyUpdateFields: Consent = {
   id: '1234',
   credentialId: '123',
@@ -123,6 +124,7 @@ describe('src/model/consent', (): void => {
             id: partialConsent.id
           })
 
+        expect(consents.length).toEqual(1)
         expect(consents[0]).toEqual(expectedPartialConsent)
       }
     )
@@ -166,13 +168,13 @@ describe('src/model/consent', (): void => {
         // Inserting record to update
         await Db<Consent>('Consent').insert(partialConsent)
 
+        // Update only selected fields of inserted record
         const updateCount: number = await consentDB.update(
           consentWithOnlyUpdateFields
         )
 
         expect(updateCount).toEqual(1)
 
-        // Assertion
         const consents: Consent[] = await Db<Consent>('Consent')
           .select('*')
           .where({
@@ -194,12 +196,10 @@ describe('src/model/consent', (): void => {
         // Inserting record to update
         await Db<Consent>('Consent').insert(partialConsent)
 
-        // Action
         const updateCount: number = await consentDB.update(conflictingConsent)
 
         expect(updateCount).toEqual(1)
 
-        // Assertion
         const consents: Consent[] = await Db<Consent>('Consent')
           .select('*')
           .where({

--- a/test/integration/model/consent.test.ts
+++ b/test/integration/model/consent.test.ts
@@ -1,0 +1,355 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the
+ Apache License, Version 2.0 (the 'License') and you may not use these files
+ except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop
+ files are distributed onan 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Raman Mangla <ramanmangla@google.com>
+ --------------
+ ******/
+
+import Knex from 'knex'
+import Config from '../../../config/knexfile'
+import ConsentDB, { Consent } from '../../../src/model/consent'
+import { NotFoundError } from '../../../src/model/errors'
+
+/*
+ * Mock Consent Resources
+ */
+const partialConsent: Consent = {
+  id: '1234',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123'
+}
+
+const completeConsent: Consent = {
+  id: '1234',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123',
+  credentialId: '123',
+  credentialType: 'FIDO',
+  credentialStatus: 'PENDING',
+  credentialChallenge: 'xyhdushsoa82w92mzs',
+  credentialPayload: 'dwuduwd&e2idjoj0w'
+}
+
+const consentWithOnlyUpdateFields: Consent = {
+  id: '1234',
+  credentialId: '123',
+  credentialType: 'FIDO',
+  credentialStatus: 'PENDING',
+  credentialChallenge: 'xyhdushsoa82w92mzs',
+  credentialPayload: 'dwuduwd&e2idjoj0w'
+}
+
+const conflictingConsent: Consent = {
+  id: '1234',
+  // Conflicting initiatorId and participantId
+  // between completeConsent and this Consent
+  initiatorId: 'pisp-0000-1133',
+  participantId: 'dfs-1233-5623',
+  credentialId: '123',
+  credentialType: 'FIDO',
+  credentialStatus: 'ACTIVE',
+  credentialChallenge: 'xyhdushsoa82w92mzs',
+  credentialPayload: 'dwuduwd&e2idjoj0w'
+}
+
+const expectedPartialConsent: object = {
+  id: '1234',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123',
+  createdAt: expect.any(Date),
+  credentialId: null,
+  credentialType: null,
+  credentialStatus: null,
+  credentialPayload: null,
+  credentialChallenge: null
+}
+
+/*
+ * Consent Resource Model Integration Tests
+ */
+describe('src/model/consent', (): void => {
+  let Db: Knex
+  let consentDB: ConsentDB
+
+  beforeAll(async (): Promise<void> => {
+    Db = Knex(Config.development as object)
+    await Db.migrate.latest()
+
+    consentDB = new ConsentDB(Db)
+  })
+
+  afterAll(async (): Promise<void> => {
+    Db.destroy()
+  })
+
+  // Reset table for new test
+  beforeEach(async (): Promise<void> => {
+    await Db<Consent>('Consent').del()
+  })
+
+  describe('insert', (): void => {
+    it('adds consent with partial info to the database',
+      async (): Promise<void> => {
+        const inserted: boolean = await consentDB.insert(partialConsent)
+
+        expect(inserted).toEqual(true)
+
+        const consents: Consent[] = await Db<Consent>('Consent')
+          .select('*')
+          .where({
+            id: partialConsent.id
+          })
+
+        expect(consents[0]).toEqual(expectedPartialConsent)
+      }
+    )
+
+    it('throws an error on adding a consent with existing consentId',
+      async (): Promise<void> => {
+        const inserted: boolean = await consentDB.insert(partialConsent)
+
+        expect(inserted).toEqual(true)
+
+        const consents: Consent[] = await Db<Consent>('Consent')
+          .select('*')
+          .where({
+            id: partialConsent.id
+          })
+
+        // Consent has been added
+        expect(consents[0]).toEqual(expectedPartialConsent)
+
+        // Fail primary key constraint
+        await expect(consentDB.insert(partialConsent)).rejects.toThrow()
+      }
+    )
+
+    it('throws an error on adding consent without an id',
+      async (): Promise<void> => {
+        const consentWithoutId: Consent = {
+          id: null as unknown as string,
+          initiatorId: '494949',
+          participantId: '3030303'
+        }
+
+        await expect(consentDB.insert(consentWithoutId)).rejects.toThrow()
+      }
+    )
+  })
+
+  describe('update', (): void => {
+    it('updates existing consent from a consent having only required fields',
+      async (): Promise<void> => {
+        // Inserting record to update
+        await Db<Consent>('Consent').insert(partialConsent)
+
+        const updateCount: number = await consentDB.update(
+          consentWithOnlyUpdateFields
+        )
+
+        expect(updateCount).toEqual(1)
+
+        // Assertion
+        const consents: Consent[] = await Db<Consent>('Consent')
+          .select('*')
+          .where({
+            id: completeConsent.id
+          })
+
+        expect(consents[0].id).toEqual(partialConsent.id)
+        expect(consents[0].createdAt).toEqual(expect.any(Date))
+        expect(consents[0]).toEqual(
+          expect.objectContaining(consentWithOnlyUpdateFields)
+        )
+      }
+    )
+
+    // credentialStatus is non-conflicting if not `ACTIVE`
+    // Any other field is non-conflicting if not null
+    it('updates existing consent with only non-conflicting fields from consent',
+      async (): Promise<void> => {
+        // Inserting record to update
+        await Db<Consent>('Consent').insert(partialConsent)
+
+        // Action
+        const updateCount: number = await consentDB.update(conflictingConsent)
+
+        expect(updateCount).toEqual(1)
+
+        // Assertion
+        const consents: Consent[] = await Db<Consent>('Consent')
+          .select('*')
+          .where({
+            id: completeConsent.id
+          })
+
+        const expectedConsent: Consent = {
+          // Conflicting fields (initiatorId, participantId) are still the same
+          ...partialConsent,
+          createdAt: expect.any(Date),
+          // Rest of the fields are updated
+          credentialId: conflictingConsent.credentialId,
+          credentialStatus: conflictingConsent.credentialStatus,
+          credentialType: conflictingConsent.credentialType,
+          credentialPayload: conflictingConsent.credentialPayload,
+          credentialChallenge: conflictingConsent.credentialChallenge
+        }
+
+        expect(consents[0]).toEqual(expectedConsent)
+      }
+    )
+
+    it('updates credentialStatus if it is not null but also not ACTIVE',
+      async (): Promise<void> => {
+        // Inserting record to update
+        await Db<Consent>('Consent').insert(completeConsent)
+
+        const updateCount: number = await consentDB.update(conflictingConsent)
+
+        expect(updateCount).toEqual(1)
+
+        const consents: Consent[] = await Db<Consent>('Consent')
+          .select('*')
+          .where({
+            id: completeConsent.id
+          })
+
+        const expectedConsent: Consent = {
+          // Conflicting fields (initiatorId, participantId) are still the same
+          // Even other fields are the same
+          ...completeConsent,
+          createdAt: expect.any(Date),
+          // credentialStatus is updated to 'ACTIVE'
+          credentialStatus: 'ACTIVE'
+        }
+
+        expect(consents[0]).toEqual(expectedConsent)
+      }
+    )
+
+    it('throws an error for non-existent consent', async (): Promise<void> => {
+      await expect(consentDB.update(completeConsent))
+        .rejects.toThrowError(NotFoundError)
+    })
+  })
+
+  describe('retrieve', (): void => {
+    it('retrieves an existing consent', async (): Promise<void> => {
+      await Db<Consent>('Consent').insert(completeConsent)
+
+      const consent: Consent = await consentDB.retrieve(completeConsent.id)
+
+      expect(consent.createdAt).toEqual(expect.any(Date))
+      expect(consent).toEqual(expect.objectContaining(completeConsent))
+    })
+
+    it('throws an error for non-existent consent', async (): Promise<void> => {
+      await expect(consentDB.retrieve(completeConsent.id))
+        .rejects.toThrowError(NotFoundError)
+    })
+  })
+
+  describe('delete', (): void => {
+    it('deletes an existing consent', async (): Promise<void> => {
+      await Db<Consent>('Consent').insert(completeConsent)
+
+      let consents: Consent[] = await Db<Consent>('Consent')
+        .select('*')
+        .where({
+          id: completeConsent.id
+        })
+
+      // Inserted properly
+      expect(consents.length).toEqual(1)
+
+      const deleteCount: number = await consentDB.delete(completeConsent.id)
+
+      expect(deleteCount).toEqual(1)
+
+      consents = await Db<Consent>('Consent')
+        .select('*')
+        .where({
+          id: completeConsent.id
+        })
+
+      // Deleted properly
+      expect(consents.length).toEqual(0)
+    })
+
+    it('throws an error for non-existent consent', async (): Promise<void> => {
+      await expect(consentDB.delete(completeConsent.id))
+        .rejects.toThrowError(NotFoundError)
+    })
+
+    it('deletes associated scopes on deleting a consent',
+      async (): Promise<void> => {
+        const tempScopes: object[] = [
+          {
+            consentId: '1234',
+            action: 'accounts.transfer',
+            accountId: '78901-12345'
+          },
+          {
+            consentId: '1234',
+            action: 'accounts.balance',
+            accountId: '38383-22992'
+          }
+        ]
+
+        await Db<Consent>('Consent').insert(completeConsent)
+        // Insert associated scopes
+        await Db('Scope').insert(tempScopes)
+
+        let scopes = await Db('Scope')
+          .select('*')
+          .where({
+            consentId: completeConsent.id
+          })
+
+        expect(scopes.length).toEqual(2)
+
+        const deleteCount: number = await consentDB.delete(completeConsent.id)
+
+        expect(deleteCount).toEqual(1)
+
+        scopes = await Db('Scope')
+          .select('*')
+          .where({
+            consentId: completeConsent.id
+          })
+
+        const consents = await Db('Consent')
+          .select('*')
+          .where({
+            id: completeConsent.id
+          })
+
+        // Confirm empty table
+        expect(consents.length).toEqual(0)
+        expect(scopes.length).toEqual(0)
+      }
+    )
+  })
+})

--- a/test/integration/model/consent.test.ts
+++ b/test/integration/model/consent.test.ts
@@ -250,7 +250,7 @@ describe('src/model/consent', (): void => {
       }
     )
 
-    it('throws an error for non-existent consent', async (): Promise<void> => {
+    it('throws an error on updating non-existent consent', async (): Promise<void> => {
       await expect(consentDB.update(completeConsent))
         .rejects.toThrowError(NotFoundError)
     })
@@ -266,7 +266,7 @@ describe('src/model/consent', (): void => {
       expect(consent).toEqual(expect.objectContaining(completeConsent))
     })
 
-    it('throws an error for non-existent consent', async (): Promise<void> => {
+    it('throws an error on retrieving non-existent consent', async (): Promise<void> => {
       await expect(consentDB.retrieve(completeConsent.id))
         .rejects.toThrowError(NotFoundError)
     })
@@ -299,7 +299,7 @@ describe('src/model/consent', (): void => {
       expect(consents.length).toEqual(0)
     })
 
-    it('throws an error for non-existent consent', async (): Promise<void> => {
+    it('throws an error on deleting non-existent consent', async (): Promise<void> => {
       await expect(consentDB.delete(completeConsent.id))
         .rejects.toThrowError(NotFoundError)
     })

--- a/test/integration/model/scope.test.ts
+++ b/test/integration/model/scope.test.ts
@@ -1,0 +1,201 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the
+ Apache License, Version 2.0 (the 'License') and you may not use these files
+ except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop
+ files are distributed onan 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Raman Mangla <ramanmangla@google.com>
+ --------------
+ ******/
+
+import Knex from 'knex'
+import Config from '../../../config/knexfile'
+import ScopeDB, { Scope } from '../../../src/model/scope'
+import { Consent } from '../../../src/model/consent'
+import { NotFoundError } from '../../../src/model/errors'
+
+/*
+ * Mock Consent Resources
+ */
+const partialConsents: Consent[] = [
+  {
+    id: '1234',
+    initiatorId: 'pisp-2342-2233',
+    participantId: 'dfsp-3333-2123'
+  },
+  {
+    id: '948',
+    initiatorId: 'pisp-2342-2013',
+    participantId: 'dfsp-3333-2773'
+  }
+]
+
+/*
+ * Mock Scope Resources
+ */
+const tempScopes: Scope[] = [
+  {
+    consentId: partialConsents[0].id,
+    action: 'transfer',
+    accountId: 'sjdn-3333-2123'
+  },
+  {
+    consentId: partialConsents[0].id,
+    action: 'balance',
+    accountId: 'sjdn-q333-2123'
+  },
+  {
+    consentId: partialConsents[0].id,
+    action: 'saving',
+    accountId: 'sjdn-q333-2123'
+  }
+]
+
+/*
+ * Scope Resource Model Integration Tests
+ */
+describe('src/model/scope', (): void => {
+  let Db: Knex
+  let scopeDB: ScopeDB
+
+  beforeAll(async (): Promise<void> => {
+    Db = Knex(Config.development as object)
+    await Db.migrate.latest()
+
+    scopeDB = new ScopeDB(Db)
+  })
+
+  afterAll(async (): Promise<void> => {
+    Db.destroy()
+  })
+
+  // Reset table for new test
+  beforeEach(async (): Promise<void> => {
+    await Db<Consent>('Consent').del()
+    await Db<Scope>('Scope').del()
+    await Db<Consent>('Consent').insert(partialConsents)
+  })
+
+  describe('insert', (): void => {
+    it('adds scope for an existing consent to the database',
+      async (): Promise<void> => {
+        const inserted: boolean = await scopeDB.insert(tempScopes[0])
+
+        // Return type check
+        expect(inserted).toEqual(true)
+
+        const scopes: Scope[] = await Db<Scope>('Scope')
+          .select('*')
+          .where({
+            consentId: partialConsents[0].id
+          })
+
+        expect(scopes.length).toEqual(1)
+        expect(scopes[0].id).toEqual(expect.any(Number))
+        expect(scopes[0]).toEqual(expect.objectContaining(tempScopes[0]))
+      }
+    )
+
+    it('adds multiple scopes for an existing consent to the database',
+      async (): Promise<void> => {
+        const inserted: boolean = await scopeDB.insert(tempScopes)
+
+        // Return type check
+        expect(inserted).toEqual(true)
+
+        const scopes: Scope[] = await Db<Scope>('Scope')
+          .select('*')
+          .where({
+            consentId: partialConsents[0].id
+          })
+
+        expect(scopes.length).toEqual(3)
+        // Ensure scopes belong to the same consent
+        expect(scopes[0].consentId === scopes[1].consentId).toEqual(true)
+        expect(scopes[1].consentId === scopes[2].consentId).toEqual(true)
+        // Ensure scopes are different
+        expect(scopes[0].action !== scopes[1].action).toEqual(true)
+        expect(scopes[1].action !== scopes[2].action).toEqual(true)
+      }
+    )
+
+    it('throws an error on adding a scope for non-existent consent',
+      async (): Promise<void> => {
+        await Db<Consent>('Consent').del()
+        await expect(scopeDB.insert(tempScopes[0])).rejects.toThrow()
+      }
+    )
+
+    it('returns without affecting the DB on inserting empty scopes array',
+      async (): Promise<void> => {
+        const scopesInitial: Scope[] = await Db<Scope>('Scope').select('*')
+
+        const inserted: boolean = await scopeDB.insert([])
+
+        const scopesAfter: Scope[] = await Db<Scope>('Scope').select('*')
+
+        expect(inserted).toEqual(true)
+        // No effect on the DB
+        expect(scopesInitial.length === scopesAfter.length)
+      }
+    )
+  })
+
+  describe('retrieveAll', (): void => {
+    it('retrieves only existing scopes from the database',
+      async (): Promise<void> => {
+        await Db<Scope>('Scope').insert(tempScopes)
+
+        const scopes: Scope[] = await scopeDB.retrieveAll(
+          tempScopes[0].consentId
+        )
+
+        expect(scopes.length).toEqual(3)
+        // id is autogenerated in the DB
+        expect(scopes[0].id).toEqual(expect.any(Number))
+        expect(scopes[1].id).toEqual(expect.any(Number))
+        expect(scopes[2].id).toEqual(expect.any(Number))
+        // Ensure scopes belong to the same consent
+        expect(scopes[0].consentId === scopes[1].consentId).toEqual(true)
+        expect(scopes[1].consentId === scopes[2].consentId).toEqual(true)
+        // Ensure scopes are different
+        expect(scopes[0].action !== scopes[1].action).toEqual(true)
+        expect(scopes[1].action !== scopes[2].action).toEqual(true)
+      }
+    )
+
+    it('throws an error on retrieving non-existent scopes for existing consent',
+      async (): Promise<void> => {
+        await expect(scopeDB.retrieveAll(partialConsents[0].id))
+          .rejects.toThrowError(NotFoundError)
+      }
+    )
+
+    it('throws an error on retrieving non-existent scopes for non-existent consent',
+      async (): Promise<void> => {
+        await Db<Consent>('Consent').del()
+        await expect(scopeDB.retrieveAll(partialConsents[0].id))
+          .rejects.toThrowError(NotFoundError)
+      }
+    )
+  })
+})

--- a/test/integration/seeds/scope.test.ts
+++ b/test/integration/seeds/scope.test.ts
@@ -46,19 +46,19 @@ describe('testing scope table', (): void => {
     const users: Knex.QueryBuilder[] = await db.from('Scope').select('*')
     expect(users.length).toEqual(3)
     expect(users[0]).toEqual({
-      id: 1,
+      id: expect.any(Number),
       consentId: '123',
       action: 'accounts.getBalance',
       accountId: '12345-67890'
     })
     expect(users[1]).toEqual({
-      id: 2,
+      id: expect.any(Number),
       consentId: '123',
       action: 'accounts.transfer',
       accountId: '12345-67890'
     })
     expect(users[2]).toEqual({
-      id: 3,
+      id: expect.any(Number),
       consentId: '124',
       action: 'accounts.transfer',
       accountId: '21345-67890'


### PR DESCRIPTION
In reference to tickets #368 .

 - This adds integration tests for database models with `MySQL`.
 - Also fixes a small test type error in `seeds` integration testing.

Main Work Files:
 - `test/integration/model/consent.test.ts`
 - `test/integration/model/scope.test.ts`