### PR TITLE
[Blocked] Feature/368: Add 202 Response Integration Tests for Async Handlers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             docker-compose up -d 
             chmod +x ./scripts/wait4.js
-            sh -c "./scripts/wait4.js my-sql"
+            sh -c "./scripts/wait4.js auth-service-integration"
       - run:
           name: Execute integration tests
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN adduser -D as-user
 USER as-user
 COPY --chown=as-user --from=builder /opt/auth-service .
 # cleanup
+
+# disable until problems with TS->JS transpilation solved
 # RUN npm prune --production
 EXPOSE 4004
 CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ RUN adduser -D as-user
 USER as-user
 COPY --chown=as-user --from=builder /opt/auth-service .
 # cleanup
-RUN npm prune --production
+# RUN npm prune --production
 EXPOSE 4004
 CMD ["npm", "run", "start"]

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const { pathsToModuleNameMapper } = require('ts-jest/utils')
+const { compilerOptions } = require('./tsconfig')
+
 module.exports = {
   verbose: true,
   preset: 'ts-jest',
@@ -17,5 +20,8 @@ module.exports = {
       lines: 0
     }
   },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/'
+  }),
   reporters: ['jest-junit', 'default']
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@typescript-eslint/eslint-plugin": "1.13.0",
     "@typescript-eslint/parser": "1.13.0",
     "add": "^2.0.6",
+    "axios": "^0.19.2",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.0.0",
     "eslint-config-standard": "14.1.1",

--- a/scripts/wait4.config.js
+++ b/scripts/wait4.config.js
@@ -12,7 +12,7 @@ module.exports = {
   // services definitions
   services: [
     {
-      name: 'my-sql',
+      name: 'auth-service-integration',
 
       // list of services to wait for
       wait4: [
@@ -21,6 +21,13 @@ module.exports = {
           /* Change host:port accordingly based on default.json attributbes. */
           uri: 'localhost:3306',
           method: 'mysql',
+          retries: 30
+        },
+        {
+          description: 'Auth Service',
+          /* Change host:port accordingly based on default.json attributbes. */
+          uri: 'localhost:4004',
+          method: 'ncat',
           retries: 30
         }
       ]

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,8 @@
+# auth-service/test/integration #
+> all source code files are located in [/src](../src/README.md) folder
+
+## Running Integration Tests ##
+
+- Run `docker-compose build` to build the MySQL and auth-service images
+- Run `docker-compose up` to run the built docker images
+- Run `npm run test:integration` to run the integration tests

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -5,4 +5,4 @@
 
 - Run `docker-compose build` to build the MySQL and auth-service images
 - Run `docker-compose up` to run the built docker images
-- Run `npm run test:integration` to run the integration tests
+- Run `npm run test:integration` to run the integration tests (in a separate terminal session)

--- a/test/integration/server/handlers/consents.test.ts
+++ b/test/integration/server/handlers/consents.test.ts
@@ -32,7 +32,7 @@
 // import * as Domain from '~/domain/consents'
 // import Logger from '@mojaloop/central-services-logger'
 import axios from 'axios'
-import { Consent } from '~/model/consent'
+// import { Consent } from '~/model/consent'
 
 // const mockStoreConsent = jest.spyOn(Domain, 'createAndStoreConsent')
 // const mockIsPostRequestValid = jest.spyOn(Domain, 'isPostConsentRequestValid')
@@ -81,7 +81,7 @@ import { Consent } from '~/model/consent'
 //   }
 // }
 
-describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
+describe('server/handlers/consents', (): void => {
 // beforeAll((): void => {
 //   mockIsPostRequestValid.mockReturnValue(true)
 //   mockStoreConsent.mockResolvedValue()
@@ -97,31 +97,46 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
 
   it('Should return 202 success code',
     async (): Promise<void> => {
-      const consent: Consent = {
-        id: '123'
-      }
+      // const consent: Consent = {
+      //   id: '123'
+      // }
 
       // Arrange
-      const scenariosURI = `http://0.0.0.0:4004/consents/${consent.id}/generateChallenge`
-      const options = [
-        {
-          body: {
-            type: 'FIDO'
+      const scenariosURI = 'http://0.0.0.0:4004/consents'
+      const body = {
+        id: 'e3488c3a-a4f3-25a7-aa7a-fdc3994bb3ec',
+        requestId: '179395e8-8dd7-16a0-99f9-0da8f0c51c7f',
+        initiatorId: 'pispa',
+        participantId: 'dfspa',
+        scopes: [
+          {
+            scope: 'accounts.getBalance',
+            accountId: 'dfspa.alice.1234'
+          },
+          {
+            scope: 'accounts.transfer',
+            accountId: 'dfspa.alice.1234'
           }
-        }
-      ]
-
-      // Add README.md
-
-      try {
-        await axios.post(scenariosURI, options)
-      } catch (err) {
-        console.log(err.response)
+        ]
       }
 
-      // expect(result.data).toEqual({})
+      const headers = {
+        date: new Date(),
+        'fspiop-source': 'third-party API',
+        'fspiop-destination': 'auth-service'
+      }
 
-      // expect(result.status).toBe(202)
+      // let response: AxiosResponse
+
+      // try {
+      const response = await axios.post(scenariosURI, body, {
+        headers: headers
+      })
+
+      expect(response.status).toEqual(202)
+      // } catch (err) {
+      // console.log(err.response)
+      // }
     }
   )
 
@@ -156,32 +171,32 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
 })
 
 // {
-//   "$ref": "#/parameters/Content-Length"
+//   '$ref': '#/parameters/Content-Length'
 // },
 // {
-//   "$ref": "#/parameters/Content-Type"
+//   '$ref': '#/parameters/Content-Type'
 // },
 // {
-//   "$ref": "#/parameters/Date"
+//   '$ref': '#/parameters/Date'
 // },
 // {
-//   "$ref": "#/parameters/X-Forwarded-For"
+//   '$ref': '#/parameters/X-Forwarded-For'
 // },
 // {
-//   "$ref": "#/parameters/FSPIOP-Source"
+//   '$ref': '#/parameters/FSPIOP-Source'
 // },
 // {
-//   "$ref": "#/parameters/FSPIOP-Destination"
+//   '$ref': '#/parameters/FSPIOP-Destination'
 // },
 // {
-//   "$ref": "#/parameters/FSPIOP-Encryption"
+//   '$ref': '#/parameters/FSPIOP-Encryption'
 // },
 // {
-//   "$ref": "#/parameters/FSPIOP-Signature"
+//   '$ref': '#/parameters/FSPIOP-Signature'
 // },
 // {
-//   "$ref": "#/parameters/FSPIOP-URI"
+//   '$ref': '#/parameters/FSPIOP-URI'
 // },
 // {
-//   "$ref": "#/parameters/FSPIOP-HTTP-Method"
+//   '$ref': '#/parameters/FSPIOP-HTTP-Method'
 // }

--- a/test/integration/server/handlers/consents.test.ts
+++ b/test/integration/server/handlers/consents.test.ts
@@ -95,7 +95,7 @@ describe('server/handlers/consents', (): void => {
   //   jest.clearAllMocks()
   // })
 
-  it('Should return 202 success code',
+  it('Should return 202 (Accepted) status code',
     async (): Promise<void> => {
       // const consent: Consent = {
       //   id: '123'

--- a/test/integration/server/handlers/consents.test.ts
+++ b/test/integration/server/handlers/consents.test.ts
@@ -41,6 +41,7 @@ describe('server/handlers/consents', (): void => {
         requestId: '179395e8-8dd7-16a0-99f9-0da8f0c51c7f',
         initiatorId: 'pispa',
         participantId: 'dfspa',
+
         // TODO: `scope` should be `action` and should be an array of strings.
         // Test needs to be changed once OpenAPI spec is updated.
         scopes: [
@@ -53,6 +54,7 @@ describe('server/handlers/consents', (): void => {
             accountId: 'dfspa.alice.1234'
           }
         ],
+
         // TODO: Credential should be `null`.
         // Test needs to be changed once OpenAPI spec is updated.
         credential: {

--- a/test/integration/server/handlers/consents.test.ts
+++ b/test/integration/server/handlers/consents.test.ts
@@ -27,81 +27,16 @@
  --------------
  ******/
 
-// import { Request, ResponseToolkit, ResponseObject } from '@hapi/hapi'
-// import { post } from '~/server/handlers/consents'
-// import * as Domain from '~/domain/consents'
-// import Logger from '@mojaloop/central-services-logger'
 import axios from 'axios'
 // import { Consent } from '~/model/consent'
 
-// const mockStoreConsent = jest.spyOn(Domain, 'createAndStoreConsent')
-// const mockIsPostRequestValid = jest.spyOn(Domain, 'isPostConsentRequestValid')
-// const mockLoggerPush = jest.spyOn(Logger, 'push')
-// const mockLoggerError = jest.spyOn(Logger, 'error')
-
-/*
- * Mock Request Resources
- */
-// @ts-ignore
-// const request: Request = {
-//   headers: {
-//     fspiopsource: 'pisp-2342-2233',
-//     fspiopdestination: 'dfsp-3333-2123'
-//   },
-//   params: {
-//     id: '1234'
-//   },
-//   payload: {
-//     id: '1234',
-//     requestId: '475234',
-//     initiatorId: 'pispa',
-//     participantId: 'sfsfdf23',
-//     scopes: [
-//       {
-//         accountId: '3423',
-//         actions: ['acc.getMoney', 'acc.sendMoney']
-//       },
-//       {
-//         accountId: '232345',
-//         actions: ['acc.accessSaving']
-//       }
-//     ],
-//     credential: null
-//   }
-// }
-
-// @ts-ignore
-// const h: ResponseToolkit = {
-//   response: (): ResponseObject => {
-//     return {
-//       code: (num: number): ResponseObject => {
-//         return num as unknown as ResponseObject
-//       }
-//     } as unknown as ResponseObject
-//   }
-// }
-
 describe('server/handlers/consents', (): void => {
-// beforeAll((): void => {
-//   mockIsPostRequestValid.mockReturnValue(true)
-//   mockStoreConsent.mockResolvedValue()
-//   mockLoggerError.mockReturnValue(null)
-//   mockLoggerPush.mockReturnValue(null)
-//   jest.useFakeTimers()
-// })
-
-  // beforeEach((): void => {
-  //   jest.clearAllTimers()
-  //   jest.clearAllMocks()
-  // })
-
   it('Should return 202 (Accepted) status code',
     async (): Promise<void> => {
       // const consent: Consent = {
       //   id: '123'
       // }
 
-      // Arrange
       const scenariosURI = 'http://0.0.0.0:4004/consents'
       const body = {
         id: 'e3488c3a-a4f3-25a7-aa7a-fdc3994bb3ec',
@@ -117,86 +52,39 @@ describe('server/handlers/consents', (): void => {
             scope: 'accounts.transfer',
             accountId: 'dfspa.alice.1234'
           }
-        ]
+        ],
+        credential: {
+          id: '5678',
+          type: 'FIDO',
+          status: 'ACTIVE',
+          challenge: {
+            payload: 'base64(...)',
+            signature: 'base64(...)'
+          },
+          payload: 'base64(...)'
+        }
       }
 
+      // fsioip encryption, signature, uri, http method
+      // x forwarded for
+
       const headers = {
-        date: new Date(),
+        date: new Date().toJSON(),
         'fspiop-source': 'third-party API',
         'fspiop-destination': 'auth-service'
       }
 
       // let response: AxiosResponse
 
-      // try {
-      const response = await axios.post(scenariosURI, body, {
-        headers: headers
-      })
+      try {
+        const response = await axios.post(scenariosURI, body, {
+          headers: headers
+        })
 
-      expect(response.status).toEqual(202)
-      // } catch (err) {
-      // console.log(err.response)
-      // }
+        expect(response.status).toEqual(202)
+      } catch (err) {
+        console.log(err.response)
+      }
     }
   )
-
-  // it('Should return 400 code due to invalid request',
-  //   async (): Promise<void> => {
-  //     mockIsPostRequestValid.mockReturnValueOnce(false)
-
-  //     const response = await post(
-  //       request as Request,
-  //       h as ResponseToolkit
-  //     )
-  //     expect(response).toBe(400)
-  //     expect(mockIsPostRequestValid).toHaveBeenCalledWith(request)
-
-  //     expect(setImmediate).not.toHaveBeenCalled()
-  //     expect(mockStoreConsent).not.toHaveBeenCalled()
-  //   })
-
-  // it('Should throw an error due to error in creating/storing consent & scopes',
-  //   async (): Promise<void> => {
-  //     mockStoreConsent.mockRejectedValueOnce(
-  //       new Error('Error Registering Consent'))
-
-  //     const response = await post(request as Request, h as ResponseToolkit)
-  //     expect(response).toBe(202)
-  //     jest.runAllImmediates()
-
-//     expect(setImmediate).toHaveBeenCalled()
-//     expect(mockStoreConsent).toHaveBeenLastCalledWith(request)
-//     expect(mockStoreConsent).not.toHaveLastReturnedWith('')
-//   })
 })
-
-// {
-//   '$ref': '#/parameters/Content-Length'
-// },
-// {
-//   '$ref': '#/parameters/Content-Type'
-// },
-// {
-//   '$ref': '#/parameters/Date'
-// },
-// {
-//   '$ref': '#/parameters/X-Forwarded-For'
-// },
-// {
-//   '$ref': '#/parameters/FSPIOP-Source'
-// },
-// {
-//   '$ref': '#/parameters/FSPIOP-Destination'
-// },
-// {
-//   '$ref': '#/parameters/FSPIOP-Encryption'
-// },
-// {
-//   '$ref': '#/parameters/FSPIOP-Signature'
-// },
-// {
-//   '$ref': '#/parameters/FSPIOP-URI'
-// },
-// {
-//   '$ref': '#/parameters/FSPIOP-HTTP-Method'
-// }

--- a/test/integration/server/handlers/consents.test.ts
+++ b/test/integration/server/handlers/consents.test.ts
@@ -43,7 +43,8 @@ describe('server/handlers/consents', (): void => {
         participantId: 'dfspa',
 
         // TODO: `scope` should be `action` and should be an array of strings.
-        // Test needs to be changed once OpenAPI spec is updated.
+        // Test needs to be changed once OpenAPI spec is updated
+        // in Ticket #412.
         scopes: [
           {
             scope: 'accounts.getBalance',
@@ -56,7 +57,8 @@ describe('server/handlers/consents', (): void => {
         ],
 
         // TODO: Credential should be `null`.
-        // Test needs to be changed once OpenAPI spec is updated.
+        // Test needs to be changed once OpenAPI spec is updated
+        // in Ticket #412.
         credential: {
           id: '5678',
           type: 'FIDO',

--- a/test/integration/server/handlers/consents.test.ts
+++ b/test/integration/server/handlers/consents.test.ts
@@ -28,21 +28,21 @@
  ******/
 
 import axios from 'axios'
-// import { Consent } from '~/model/consent'
 
 describe('server/handlers/consents', (): void => {
   it('Should return 202 (Accepted) status code',
     async (): Promise<void> => {
-      // const consent: Consent = {
-      //   id: '123'
-      // }
-
+      // Endpoint
       const scenariosURI = 'http://0.0.0.0:4004/consents'
+
+      // Request parameters
       const body = {
         id: 'e3488c3a-a4f3-25a7-aa7a-fdc3994bb3ec',
         requestId: '179395e8-8dd7-16a0-99f9-0da8f0c51c7f',
         initiatorId: 'pispa',
         participantId: 'dfspa',
+        // TODO: `scope` should be `action` and should be an array of strings.
+        // Test needs to be changed once OpenAPI spec is updated.
         scopes: [
           {
             scope: 'accounts.getBalance',
@@ -53,6 +53,8 @@ describe('server/handlers/consents', (): void => {
             accountId: 'dfspa.alice.1234'
           }
         ],
+        // TODO: Credential should be `null`.
+        // Test needs to be changed once OpenAPI spec is updated.
         credential: {
           id: '5678',
           type: 'FIDO',
@@ -65,26 +67,17 @@ describe('server/handlers/consents', (): void => {
         }
       }
 
-      // fsioip encryption, signature, uri, http method
-      // x forwarded for
-
       const headers = {
         date: new Date().toJSON(),
-        'fspiop-source': 'third-party API',
+        'fspiop-source': body.participantId,
         'fspiop-destination': 'auth-service'
       }
 
-      // let response: AxiosResponse
+      const response = await axios.post(scenariosURI, body, {
+        headers: headers
+      })
 
-      try {
-        const response = await axios.post(scenariosURI, body, {
-          headers: headers
-        })
-
-        expect(response.status).toEqual(202)
-      } catch (err) {
-        console.log(err.response)
-      }
+      expect(response.status).toEqual(202)
     }
   )
 })

--- a/test/integration/server/handlers/consents/{ID}/generateChallenge.test.ts
+++ b/test/integration/server/handlers/consents/{ID}/generateChallenge.test.ts
@@ -1,0 +1,62 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the
+ Apache License, Version 2.0 (the 'License') and you may not use these files
+ except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop
+ files are distributed onan 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Raman Mangla <ramanmangla@google.com>
+ --------------
+ ******/
+
+import axios from 'axios'
+
+describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
+  it('Should return 202 (Accepted) status code',
+    async (): Promise<void> => {
+      const consentId = 'e3488c3a-a4f3-25a7-aa7a-fdc3994bb3ec1'
+
+      // Endpoint
+      const scenariosURI = `http://0.0.0.0:4004/consents/${consentId}/generateChallenge`
+
+      // Request parameters
+      const body = {
+        type: 'FIDO'
+      }
+
+      const headers = {
+        date: new Date().toJSON(),
+        'fspiop-source': 'dfspa',
+        'fspiop-destination': 'auth-service'
+      }
+
+      try {
+        const response = await axios.post(scenariosURI, body, {
+          headers: headers
+        })
+
+        expect(response.status).toEqual(202)
+      } catch (err) {
+        console.log(err.response)
+      }
+    }
+  )
+})

--- a/test/integration/server/handlers/consents/{ID}/generateChallenge.test.ts
+++ b/test/integration/server/handlers/consents/{ID}/generateChallenge.test.ts
@@ -31,8 +31,8 @@
 // import { post } from '~/server/handlers/consents'
 // import * as Domain from '~/domain/consents'
 // import Logger from '@mojaloop/central-services-logger'
-// import axios from 'axios'
-// import { Consent } from '~/model/consent'
+import axios from 'axios'
+import { Consent } from '~/model/consent'
 
 // const mockStoreConsent = jest.spyOn(Domain, 'createAndStoreConsent')
 // const mockIsPostRequestValid = jest.spyOn(Domain, 'isPostConsentRequestValid')
@@ -81,7 +81,7 @@
 //   }
 // }
 
-// describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
+describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
 // beforeAll((): void => {
 //   mockIsPostRequestValid.mockReturnValue(true)
 //   mockStoreConsent.mockResolvedValue()
@@ -90,62 +90,98 @@
 //   jest.useFakeTimers()
 // })
 
-// beforeEach((): void => {
-//   jest.clearAllTimers()
-//   jest.clearAllMocks()
-// })
+  // beforeEach((): void => {
+  //   jest.clearAllTimers()
+  //   jest.clearAllMocks()
+  // })
 
-// it('Should return 202 success code',
-//   async (): Promise<void> => {
-//     const consent: Consent = {
-//       id: '123'
-//     }
+  it('Should return 202 success code',
+    async (): Promise<void> => {
+      const consent: Consent = {
+        id: '123'
+      }
 
-//     // Arrange
-//     const scenariosURI = `http://localhost:4004/consents/${consent.id}/generateChallenge`
-//     const options = [
-//       {
-//         body: {
-//           type: 'FIDO'
-//         }
-//       }
-//     ]
+      // Arrange
+      const scenariosURI = `http://0.0.0.0:4004/consents/${consent.id}/generateChallenge`
+      const options = [
+        {
+          body: {
+            type: 'FIDO'
+          }
+        }
+      ]
 
-//     // Add README.md
+      // Add README.md
 
-//     const result = await axios.post(scenariosURI, options)
-//     console.log(result)
+      try {
+        await axios.post(scenariosURI, options)
+      } catch (err) {
+        console.log(err.response)
+      }
 
-//     expect(result.status).toBe(202)
-//   }
-// )
+      // expect(result.data).toEqual({})
 
-// it('Should return 400 code due to invalid request',
-//   async (): Promise<void> => {
-//     mockIsPostRequestValid.mockReturnValueOnce(false)
+      // expect(result.status).toBe(202)
+    }
+  )
 
-//     const response = await post(
-//       request as Request,
-//       h as ResponseToolkit
-//     )
-//     expect(response).toBe(400)
-//     expect(mockIsPostRequestValid).toHaveBeenCalledWith(request)
+  // it('Should return 400 code due to invalid request',
+  //   async (): Promise<void> => {
+  //     mockIsPostRequestValid.mockReturnValueOnce(false)
 
-//     expect(setImmediate).not.toHaveBeenCalled()
-//     expect(mockStoreConsent).not.toHaveBeenCalled()
-//   })
+  //     const response = await post(
+  //       request as Request,
+  //       h as ResponseToolkit
+  //     )
+  //     expect(response).toBe(400)
+  //     expect(mockIsPostRequestValid).toHaveBeenCalledWith(request)
 
-// it('Should throw an error due to error in creating/storing consent & scopes',
-//   async (): Promise<void> => {
-//     mockStoreConsent.mockRejectedValueOnce(
-//       new Error('Error Registering Consent'))
+  //     expect(setImmediate).not.toHaveBeenCalled()
+  //     expect(mockStoreConsent).not.toHaveBeenCalled()
+  //   })
 
-//     const response = await post(request as Request, h as ResponseToolkit)
-//     expect(response).toBe(202)
-//     jest.runAllImmediates()
+  // it('Should throw an error due to error in creating/storing consent & scopes',
+  //   async (): Promise<void> => {
+  //     mockStoreConsent.mockRejectedValueOnce(
+  //       new Error('Error Registering Consent'))
+
+  //     const response = await post(request as Request, h as ResponseToolkit)
+  //     expect(response).toBe(202)
+  //     jest.runAllImmediates()
 
 //     expect(setImmediate).toHaveBeenCalled()
 //     expect(mockStoreConsent).toHaveBeenLastCalledWith(request)
 //     expect(mockStoreConsent).not.toHaveLastReturnedWith('')
 //   })
-// })
+})
+
+// {
+//   "$ref": "#/parameters/Content-Length"
+// },
+// {
+//   "$ref": "#/parameters/Content-Type"
+// },
+// {
+//   "$ref": "#/parameters/Date"
+// },
+// {
+//   "$ref": "#/parameters/X-Forwarded-For"
+// },
+// {
+//   "$ref": "#/parameters/FSPIOP-Source"
+// },
+// {
+//   "$ref": "#/parameters/FSPIOP-Destination"
+// },
+// {
+//   "$ref": "#/parameters/FSPIOP-Encryption"
+// },
+// {
+//   "$ref": "#/parameters/FSPIOP-Signature"
+// },
+// {
+//   "$ref": "#/parameters/FSPIOP-URI"
+// },
+// {
+//   "$ref": "#/parameters/FSPIOP-HTTP-Method"
+// }

--- a/test/integration/server/handlers/consents/{ID}/generateChallenge.test.ts
+++ b/test/integration/server/handlers/consents/{ID}/generateChallenge.test.ts
@@ -1,0 +1,151 @@
+/*****
+ License
+ --------------
+ Copyright © 2020 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the
+ Apache License, Version 2.0 (the 'License') and you may not use these files
+ except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop
+ files are distributed onan 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ - Raman Mangla <ramanmangla@google.com>
+ --------------
+ ******/
+
+// import { Request, ResponseToolkit, ResponseObject } from '@hapi/hapi'
+// import { post } from '~/server/handlers/consents'
+// import * as Domain from '~/domain/consents'
+// import Logger from '@mojaloop/central-services-logger'
+// import axios from 'axios'
+// import { Consent } from '~/model/consent'
+
+// const mockStoreConsent = jest.spyOn(Domain, 'createAndStoreConsent')
+// const mockIsPostRequestValid = jest.spyOn(Domain, 'isPostConsentRequestValid')
+// const mockLoggerPush = jest.spyOn(Logger, 'push')
+// const mockLoggerError = jest.spyOn(Logger, 'error')
+
+/*
+ * Mock Request Resources
+ */
+// @ts-ignore
+// const request: Request = {
+//   headers: {
+//     fspiopsource: 'pisp-2342-2233',
+//     fspiopdestination: 'dfsp-3333-2123'
+//   },
+//   params: {
+//     id: '1234'
+//   },
+//   payload: {
+//     id: '1234',
+//     requestId: '475234',
+//     initiatorId: 'pispa',
+//     participantId: 'sfsfdf23',
+//     scopes: [
+//       {
+//         accountId: '3423',
+//         actions: ['acc.getMoney', 'acc.sendMoney']
+//       },
+//       {
+//         accountId: '232345',
+//         actions: ['acc.accessSaving']
+//       }
+//     ],
+//     credential: null
+//   }
+// }
+
+// @ts-ignore
+// const h: ResponseToolkit = {
+//   response: (): ResponseObject => {
+//     return {
+//       code: (num: number): ResponseObject => {
+//         return num as unknown as ResponseObject
+//       }
+//     } as unknown as ResponseObject
+//   }
+// }
+
+// describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
+// beforeAll((): void => {
+//   mockIsPostRequestValid.mockReturnValue(true)
+//   mockStoreConsent.mockResolvedValue()
+//   mockLoggerError.mockReturnValue(null)
+//   mockLoggerPush.mockReturnValue(null)
+//   jest.useFakeTimers()
+// })
+
+// beforeEach((): void => {
+//   jest.clearAllTimers()
+//   jest.clearAllMocks()
+// })
+
+// it('Should return 202 success code',
+//   async (): Promise<void> => {
+//     const consent: Consent = {
+//       id: '123'
+//     }
+
+//     // Arrange
+//     const scenariosURI = `http://localhost:4004/consents/${consent.id}/generateChallenge`
+//     const options = [
+//       {
+//         body: {
+//           type: 'FIDO'
+//         }
+//       }
+//     ]
+
+//     // Add README.md
+
+//     const result = await axios.post(scenariosURI, options)
+//     console.log(result)
+
+//     expect(result.status).toBe(202)
+//   }
+// )
+
+// it('Should return 400 code due to invalid request',
+//   async (): Promise<void> => {
+//     mockIsPostRequestValid.mockReturnValueOnce(false)
+
+//     const response = await post(
+//       request as Request,
+//       h as ResponseToolkit
+//     )
+//     expect(response).toBe(400)
+//     expect(mockIsPostRequestValid).toHaveBeenCalledWith(request)
+
+//     expect(setImmediate).not.toHaveBeenCalled()
+//     expect(mockStoreConsent).not.toHaveBeenCalled()
+//   })
+
+// it('Should throw an error due to error in creating/storing consent & scopes',
+//   async (): Promise<void> => {
+//     mockStoreConsent.mockRejectedValueOnce(
+//       new Error('Error Registering Consent'))
+
+//     const response = await post(request as Request, h as ResponseToolkit)
+//     expect(response).toBe(202)
+//     jest.runAllImmediates()
+
+//     expect(setImmediate).toHaveBeenCalled()
+//     expect(mockStoreConsent).toHaveBeenLastCalledWith(request)
+//     expect(mockStoreConsent).not.toHaveLastReturnedWith('')
+//   })
+// })

--- a/test/integration/server/handlers/thirdpartyRequests/transactions/{ID}/authorizations.test.ts
+++ b/test/integration/server/handlers/thirdpartyRequests/transactions/{ID}/authorizations.test.ts
@@ -37,7 +37,8 @@ describe('server/handlers/thirdpartyRequests/transactions/{ID}/authorizations',
 
         // TODO: URI should be
         // `/thirdpartyRequests/transactions/{ID}/authorizations`
-        // Test needs to be changed once OpenAPI spec is updated.
+        // Test needs to be changed once OpenAPI spec is updated
+        // in Ticket #412.
         const scenariosURI = `http://0.0.0.0:4004/thirdPartyRequests/transactions/${transactionId}/authorizations`
 
         // Request parameters

--- a/test/integration/server/handlers/thirdpartyRequests/transactions/{ID}/authorizations.test.ts
+++ b/test/integration/server/handlers/thirdpartyRequests/transactions/{ID}/authorizations.test.ts
@@ -29,34 +29,38 @@
 
 import axios from 'axios'
 
-describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
-  it('Should return 202 (Accepted) status code',
-    async (): Promise<void> => {
-      const consentId = 'e3488c3a-a4f3-25a7-aa7a-fdc3994bb3ec'
+describe('server/handlers/thirdpartyRequests/transactions/{ID}/authorizations',
+  (): void => {
+    it('Should return 202 (Accepted) status code',
+      async (): Promise<void> => {
+        const transactionId = '179395e8-8dd7-16a0-99f9-0da8f0c51c7f'
 
-      // Endpoint
-      const scenariosURI = `http://0.0.0.0:4004/consents/${consentId}/generateChallenge`
+        // TODO: URI should be
+        // `/thirdpartyRequests/transactions/{ID}/authorizations`
+        // Test needs to be changed once OpenAPI spec is updated.
+        const scenariosURI = `http://0.0.0.0:4004/thirdPartyRequests/transactions/${transactionId}/authorizations`
 
-      // Request parameters
-      const body = {
-        type: 'FIDO'
+        // Request parameters
+        const body = {
+          challenge: 'I am trying ot test this',
+          value: 'dhX6AGncg6kxnXAwsZlBotrqjDsHVAm9Fz8NaAwdwDkfhDNDclM74==',
+          consentId: 'e3488c3a-a4f3-25a7-aa7a-fdc3994bb3ec',
+          sourceAccountId: 'dfspa.alice.1234',
+          status: 'PENDING'
+        }
+
+        const headers = {
+          date: new Date().toJSON(),
+          'fspiop-source': 'dfspa',
+          'fspiop-destination': 'auth-service'
+        }
+
+        const response = await axios.post(scenariosURI, body, {
+          headers: headers
+        })
+
+        expect(response.status).toEqual(202)
       }
-
-      const headers = {
-        date: new Date().toJSON(),
-        'fspiop-source': 'dfspa',
-        'fspiop-destination': 'auth-service'
-      }
-
-      // try {
-      const response = await axios.post(scenariosURI, body, {
-        headers: headers
-      })
-
-      expect(response.status).toEqual(202)
-      // } catch (err) {
-      // console.log(err.response)
-      // }
-    }
-  )
-})
+    )
+  }
+)


### PR DESCRIPTION
In reference to tickets #368 .

 - This adds integration tests for 202 response from the merged handlers to verify correct working.
 - Modifies `Dockerfile`, `wait4.config.js` and CircleCI files to run containerized `auth-service` along with `MySQL` for handler tests