### PR TITLE
417 - Improving Unit Test Readability and Coverage + Setting up Central Mocked Resources Data File

### DIFF
--- a/seeds/01_consent.ts
+++ b/seeds/01_consent.ts
@@ -68,6 +68,30 @@ const consents = [
     credentialPayload: 'string_representing_public_key_a',
     credentialChallenge: 'string_representing_challenge_b',
     revokedAt: null
+  },
+  {
+    id: '126',
+    status: 'REVOKED',
+    initiatorId: 'PISPC',
+    participantId: 'DFSPA',
+    credentialId: '9875',
+    credentialType: 'FIDO',
+    credentialStatus: 'VERIFIED',
+    credentialPayload: 'string_representing_public_key_a',
+    credentialChallenge: 'string_representing_challenge_b',
+    revokedAt: '2011-10-05T14:48:00.000Z'
+  },
+  {
+    id: '127',
+    status: 'REVOKED',
+    initiatorId: 'PISPA',
+    participantId: 'DFSPA',
+    credentialId: null,
+    credentialType: null,
+    credentialStatus: null,
+    credentialPayload: null,
+    credentialChallenge: null,
+    revokedAt: '2020-08-19T05:44:18.843Z'
   }
 ]
 

--- a/src/domain/consents/revoke.ts
+++ b/src/domain/consents/revoke.ts
@@ -62,8 +62,9 @@ export async function revokeConsentStatus (
 export function generatePatchRevokedConsentRequest (
   consent: Consent
 ): SDKStandardComponents.PatchConsentsRequest {
-  if (consent.status !== 'REVOKED')
+  if (consent.status !== 'REVOKED') {
     throw new Error('Attempting to generate request for non-revoked consent!')
+  }
 
   const requestBody: SDKStandardComponents.PatchConsentsRequest = {
     status: 'REVOKED',

--- a/src/domain/consents/revoke.ts
+++ b/src/domain/consents/revoke.ts
@@ -50,6 +50,13 @@ export async function revokeConsentStatus (
     Logger.push('Previously revoked consent was asked to be revoked')
     return consent
   }
+  // Protects against invalid consent status types
+  if (consent.status !== 'ACTIVE') {
+    Logger.push('Invalid Consent Status')
+    // TODO: specific Error here ?
+    throw Error('Invalid Consent Status')
+  }
+
   consent.status = 'REVOKED'
   consent.revokedAt = (new Date()).toISOString()
   await consentDB.update(consent)

--- a/test/integration/seeds/consent.test.ts
+++ b/test/integration/seeds/consent.test.ts
@@ -44,7 +44,7 @@ describe('testing Consent table', (): void => {
   it('should properly select all the entries in the Consent table', async (): Promise<void> => {
     expect(db).toBeDefined()
     const users: Knex.QueryBuilder[] = await db.from('Consent').select('*')
-    expect(users.length).toEqual(3)
+    expect(users.length).toEqual(5)
     expect(users[0]).toMatchObject({
       id: '123',
       initiatorId: 'PISPA',

--- a/test/unit/data/data.ts
+++ b/test/unit/data/data.ts
@@ -1,4 +1,4 @@
-import { Consent, ConsentCredential } from '~/model/consent'
+import { Consent } from '~/model/consent'
 import { ExternalScope } from '~/lib/scopes'
 import { Request, ResponseToolkit, ResponseObject } from '@hapi/hapi'
 import { Scope } from '~/model/scope'

--- a/test/unit/data/data.ts
+++ b/test/unit/data/data.ts
@@ -18,6 +18,31 @@ export const request: Request = {
 }
 
 // @ts-ignore
+export const requestWithPayloadScopes: Request = {
+  headers: {
+    fspiopsource: 'pisp-2342-2233',
+    fspiopdestination: 'dfsp-3333-2123'
+  },
+  params: {
+    id: '1234'
+  },
+  payload: {
+    id: '1234',
+    participantId: 'auth121',
+    initiatorId: 'pispa',
+    scopes: [{
+      accountId: 'as2342',
+      actions: ['account.getAccess', 'account.transferMoney']
+    },
+    {
+      accountId: 'as22',
+      actions: ['account.getAccess']
+    }
+    ]
+  }
+}
+
+// @ts-ignore
 export const requestNoHeaders: Request = {
   params: {
     id: '1234'
@@ -58,7 +83,7 @@ export const partialConsentRevoked: Consent = {
   id: '1234',
   initiatorId: 'pisp-2342-2233',
   participantId: 'dfsp-3333-2123',
-  revokedAt: 'now',
+  revokedAt: '2020-08-19T05:44:18.843Z',
   status: 'REVOKED'
 }
 
@@ -67,7 +92,7 @@ export const completeConsentRevoked: Consent = {
   initiatorId: 'pisp-2342-2233',
   participantId: 'dfsp-3333-2123',
   status: 'REVOKED',
-  revokedAt: 'now',
+  revokedAt: '2020-08-19T05:44:18.843Z',
   credentialType: 'FIDO',
   credentialStatus: 'PENDING',
   credentialChallenge: 'xyhdushsoa82w92mzs='
@@ -107,7 +132,7 @@ export const externalScopes: ExternalScope[] = [{
 }
 ]
 
-const scopes: Scope[] = [{
+export const scopes: Scope[] = [{
   id: 123234,
   consentId: '1234',
   accountId: 'as2342',

--- a/test/unit/data/data.ts
+++ b/test/unit/data/data.ts
@@ -1,0 +1,152 @@
+import { Consent, ConsentCredential } from '~/model/consent'
+import { ExternalScope } from '~/lib/scopes'
+import { Request, ResponseToolkit, ResponseObject } from '@hapi/hapi'
+import { Scope } from '~/model/scope'
+
+/*
+ * Mock Request Resources
+ */
+// @ts-ignore
+export const request: Request = {
+  headers: {
+    'fspiop-source': 'pisp-2342-2233',
+    'fspiop-destination': 'dfsp-3333-2123'
+  },
+  params: {
+    id: '1234'
+  }
+}
+
+// @ts-ignore
+export const requestNoHeaders: Request = {
+  params: {
+    id: '1234'
+  }
+}
+
+// @ts-ignore
+export const h: ResponseToolkit = {
+  response: (): ResponseObject => {
+    return {
+      code: (num: number): ResponseObject => {
+        return {
+          statusCode: num
+        } as unknown as ResponseObject
+      }
+    } as unknown as ResponseObject
+  }
+}
+
+/*
+ * Mock Consent Resources
+ */
+export const partialConsentActive: Consent = {
+  id: '1234',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123',
+  status: 'ACTIVE'
+}
+
+export const partialConsentActiveConflictingInitiatorId: Consent = {
+  id: '1234',
+  initiatorId: 'pi2-2233',
+  participantId: 'dfs333-2123',
+  status: 'ACTIVE'
+}
+
+export const partialConsentRevoked: Consent = {
+  id: '1234',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123',
+  revokedAt: 'now',
+  status: 'REVOKED'
+}
+
+export const completeConsentRevoked: Consent = {
+  id: '1234',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123',
+  status: 'REVOKED',
+  revokedAt: 'now',
+  credentialType: 'FIDO',
+  credentialStatus: 'PENDING',
+  credentialChallenge: 'xyhdushsoa82w92mzs='
+}
+
+export const completeConsentActive: Consent = {
+  id: '1234',
+  status: 'ACTIVE',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123',
+  credentialId: '123',
+  credentialType: 'FIDO',
+  credentialStatus: 'PENDING',
+  credentialChallenge: 'xyhdushsoa82w92mzs='
+}
+
+export const completeConsentActiveNoCredentialID: Consent = {
+  id: '1234',
+  status: 'ACTIVE',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123',
+  credentialType: 'FIDO',
+  credentialStatus: 'PENDING',
+  credentialChallenge: 'xyhdushsoa82w92mzs='
+}
+
+/*
+ * Mock Scope Resources
+*/
+export const externalScopes: ExternalScope[] = [{
+  accountId: 'as2342',
+  actions: ['account.getAccess', 'account.transferMoney']
+},
+{
+  accountId: 'as22',
+  actions: ['account.getAccess']
+}
+]
+
+const scopes: Scope[] = [{
+  id: 123234,
+  consentId: '1234',
+  accountId: 'as2342',
+  action: 'account.getAccess'
+},
+{
+  id: 232234,
+  consentId: '1234',
+  accountId: 'as2342',
+  action: 'account.transferMoney'
+},
+{
+  id: 234,
+  consentId: '1234',
+  accountId: 'as22',
+  action: 'account.getAccess'
+}
+]
+
+/*
+ * Mock Credential Resources
+*/
+
+export const credential = {
+  credentialType: 'FIDO',
+  credentialStatus: 'PENDING',
+  credentialChallenge: 'xyhdushsoa82w92mzs=',
+  credentialPayload: null
+}
+
+export const challenge = 'xyhdushsoa82w92mzs='
+
+export const completeConsentActiveCredential: Consent = {
+  id: '1234',
+  status: 'ACTIVE',
+  initiatorId: 'pisp-2342-2233',
+  participantId: 'dfsp-3333-2123',
+  credentialId: '123',
+  credentialType: 'FIDO',
+  credentialStatus: 'ACTIVE',
+  credentialChallenge: 'xyhdushsoa82w92mzs='
+}

--- a/test/unit/data/data.ts
+++ b/test/unit/data/data.ts
@@ -28,8 +28,8 @@ export const requestWithPayloadScopes: Request = {
   },
   payload: {
     id: '1234',
-    participantId: 'auth121',
-    initiatorId: 'pispa',
+    participantId: 'dfsp-3333-2123',
+    initiatorId: 'pisp-2342-2233',
     scopes: [{
       accountId: 'as2342',
       actions: ['account.getAccess', 'account.transferMoney']

--- a/test/unit/domain/consents.test.ts
+++ b/test/unit/domain/consents.test.ts
@@ -27,12 +27,12 @@
  - Abhimanyu Kapur <abhi.kapur09@gmail.com>
  --------------
  ******/
-import { Request } from '@hapi/hapi'
 import { consentDB, scopeDB } from '~/lib/db'
 import { createAndStoreConsent } from '~/domain/consents'
 import Logger from '@mojaloop/central-services-logger'
 
 import * as ScopeFunction from '~/lib/scopes'
+import { requestWithPayloadScopes } from '../data/data'
 
 // Declare Mocks
 const mockInsertConsent = jest.spyOn(consentDB, 'insert')
@@ -41,34 +41,6 @@ const mockLoggerError = jest.spyOn(Logger, 'error')
 const mockInsertScopes = jest.spyOn(scopeDB, 'insert')
 const mockConvertExternalToScope = jest.spyOn(
   ScopeFunction, 'convertExternalToScope')
-
-/*
- * Mock Request Resources
- */
-// @ts-ignore
-const request: Request = {
-  headers: {
-    fspiopsource: 'pisp-2342-2233',
-    fspiopdestination: 'dfsp-3333-2123'
-  },
-  params: {
-    id: '1234'
-  },
-  payload: {
-    id: '1234',
-    participantId: 'auth121',
-    initiatorId: 'pispa',
-    scopes: [{
-      accountId: 'as2342',
-      actions: ['account.getAccess', 'account.transferMoney']
-    },
-    {
-      accountId: 'as22',
-      actions: ['account.getAccess']
-    }
-    ]
-  }
-}
 
 const consent = {
   id: '1234',
@@ -121,7 +93,9 @@ describe('server/domain/consents', (): void => {
   })
 
   it('Should return nothing and no errors thrown', async (): Promise<void> => {
-    await expect(createAndStoreConsent(request)).resolves.toBe(undefined)
+    await expect(createAndStoreConsent(requestWithPayloadScopes))
+      .resolves
+      .toBe(undefined)
 
     expect(mockConvertExternalToScope).toHaveBeenCalledWith(externalScopes, '1234')
     expect(mockInsertConsent).toHaveBeenCalledWith(consent)
@@ -130,7 +104,9 @@ describe('server/domain/consents', (): void => {
 
   it('Should throw an error due to error in registering Consent', async (): Promise<void> => {
     mockInsertConsent.mockRejectedValueOnce(new Error('Unable to Register Consent'))
-    await expect(createAndStoreConsent(request)).rejects.toThrowError('Unable to Register Consent')
+    await expect(createAndStoreConsent(requestWithPayloadScopes))
+      .rejects
+      .toThrowError('Unable to Register Consent')
 
     expect(mockConvertExternalToScope).toHaveBeenCalledWith(externalScopes, '1234')
     expect(mockInsertConsent).toHaveBeenCalledWith(consent)
@@ -139,7 +115,9 @@ describe('server/domain/consents', (): void => {
 
   it('Should throw an error due to error in registering Scopes', async (): Promise<void> => {
     mockInsertScopes.mockRejectedValueOnce(new Error('Unable to Register Scopes'))
-    await expect(createAndStoreConsent(request)).rejects.toThrowError('Unable to Register Scopes')
+    await expect(createAndStoreConsent(requestWithPayloadScopes))
+      .rejects
+      .toThrowError('Unable to Register Scopes')
 
     expect(mockConvertExternalToScope).toHaveBeenCalledWith(externalScopes, '1234')
     expect(mockInsertConsent).toHaveBeenCalledWith(consent)

--- a/test/unit/domain/consents.test.ts
+++ b/test/unit/domain/consents.test.ts
@@ -32,7 +32,10 @@ import { createAndStoreConsent } from '~/domain/consents'
 import Logger from '@mojaloop/central-services-logger'
 
 import * as ScopeFunction from '~/lib/scopes'
-import { requestWithPayloadScopes } from '../data/data'
+import {
+  requestWithPayloadScopes, externalScopes,
+  partialConsentActive, scopes
+} from '../data/data'
 
 // Declare Mocks
 const mockInsertConsent = jest.spyOn(consentDB, 'insert')
@@ -41,43 +44,6 @@ const mockLoggerError = jest.spyOn(Logger, 'error')
 const mockInsertScopes = jest.spyOn(scopeDB, 'insert')
 const mockConvertExternalToScope = jest.spyOn(
   ScopeFunction, 'convertExternalToScope')
-
-const consent = {
-  id: '1234',
-  participantId: 'auth121',
-  initiatorId: 'pispa',
-  status: 'ACTIVE'
-}
-
-const externalScopes = [{
-  accountId: 'as2342',
-  actions: ['account.getAccess', 'account.transferMoney']
-},
-{
-  accountId: 'as22',
-  actions: ['account.getAccess']
-}
-]
-
-const scopes = [{
-  id: 123234,
-  consentId: '1234',
-  accountId: 'as2342',
-  action: 'account.getAccess'
-},
-{
-  id: 232234,
-  consentId: '1234',
-  accountId: 'as2342',
-  action: 'account.transferMoney'
-},
-{
-  id: 234,
-  consentId: '1234',
-  accountId: 'as22',
-  action: 'account.getAccess'
-}
-]
 
 describe('server/domain/consents', (): void => {
   beforeAll((): void => {
@@ -92,35 +58,35 @@ describe('server/domain/consents', (): void => {
     jest.clearAllMocks()
   })
 
-  it('Should return nothing and no errors thrown', async (): Promise<void> => {
+  it('Should resolve successfully', async (): Promise<void> => {
     await expect(createAndStoreConsent(requestWithPayloadScopes))
       .resolves
       .toBe(undefined)
 
     expect(mockConvertExternalToScope).toHaveBeenCalledWith(externalScopes, '1234')
-    expect(mockInsertConsent).toHaveBeenCalledWith(consent)
+    expect(mockInsertConsent).toHaveBeenCalledWith(partialConsentActive)
     expect(mockInsertScopes).toHaveBeenCalledWith(scopes)
   })
 
-  it('Should throw an error due to error in registering Consent', async (): Promise<void> => {
+  it('Should propagate error in inserting Consent in database', async (): Promise<void> => {
     mockInsertConsent.mockRejectedValueOnce(new Error('Unable to Register Consent'))
     await expect(createAndStoreConsent(requestWithPayloadScopes))
       .rejects
       .toThrowError('Unable to Register Consent')
 
     expect(mockConvertExternalToScope).toHaveBeenCalledWith(externalScopes, '1234')
-    expect(mockInsertConsent).toHaveBeenCalledWith(consent)
+    expect(mockInsertConsent).toHaveBeenCalledWith(partialConsentActive)
     expect(mockInsertScopes).not.toHaveBeenCalled()
   })
 
-  it('Should throw an error due to error in registering Scopes', async (): Promise<void> => {
+  it('Should propagate error in inserting Scopes in database', async (): Promise<void> => {
     mockInsertScopes.mockRejectedValueOnce(new Error('Unable to Register Scopes'))
     await expect(createAndStoreConsent(requestWithPayloadScopes))
       .rejects
       .toThrowError('Unable to Register Scopes')
 
     expect(mockConvertExternalToScope).toHaveBeenCalledWith(externalScopes, '1234')
-    expect(mockInsertConsent).toHaveBeenCalledWith(consent)
+    expect(mockInsertConsent).toHaveBeenCalledWith(partialConsentActive)
     expect(mockInsertScopes).toHaveBeenCalledWith(scopes)
   })
 })

--- a/test/unit/domain/consents/generateChallenge.test.ts
+++ b/test/unit/domain/consents/generateChallenge.test.ts
@@ -74,7 +74,7 @@ describe('Tests for src/domain/consents/{ID}/generateChallenge', (): void => {
   })
 
   // Tests for updateConsentCredential
-  describe('Updating Consent', (): void => {
+  describe('Updating Consent successfully', (): void => {
     // eslint-disable-next-line max-len
     it('Should return a consent object with filled out credentials', async (): Promise<void> => {
       mockConsentDbUpdate.mockResolvedValueOnce(3)
@@ -87,7 +87,7 @@ describe('Tests for src/domain/consents/{ID}/generateChallenge', (): void => {
     })
 
     // eslint-disable-next-line max-len
-    it('Should throw an error due to an error updating credentials', async (): Promise<void> => {
+    it('Should propagate error in updating credentials in database', async (): Promise<void> => {
       mockConsentDbUpdate.mockRejectedValue(
         new Error('Error updating Database'))
 

--- a/test/unit/domain/consents/generateChallenge.test.ts
+++ b/test/unit/domain/consents/generateChallenge.test.ts
@@ -33,8 +33,8 @@ import { Enum } from '@mojaloop/central-services-shared'
 import Logger from '@mojaloop/central-services-logger'
 import { PutConsentsRequest } from '@mojaloop/sdk-standard-components'
 import {
-  completeConsentActive, externalScopes, request,
-  credential, partialConsentActive
+  externalScopes, request,
+  credential, partialConsentActive, completeConsentActiveNoCredentialID
 } from '../../data/data'
 import {
   updateConsentCredential,
@@ -48,15 +48,15 @@ const mockLoggerError = jest.spyOn(Logger, 'error')
 
 const putConsentRequestBody: PutConsentsRequest = {
   requestId: '1234',
-  initiatorId: completeConsentActive.initiatorId as string,
-  participantId: completeConsentActive.participantId as string,
+  initiatorId: completeConsentActiveNoCredentialID.initiatorId as string,
+  participantId: completeConsentActiveNoCredentialID.participantId as string,
   scopes: externalScopes,
   credential: {
     id: null,
     credentialType: 'FIDO',
     status: 'PENDING',
     challenge: {
-      payload: completeConsentActive.credentialChallenge as string,
+      payload: completeConsentActiveNoCredentialID.credentialChallenge as string,
       signature: null
     },
     payload: null
@@ -82,8 +82,8 @@ describe('Tests for src/domain/consents/{ID}/generateChallenge', (): void => {
       const updatedConsent = await updateConsentCredential(
         partialConsentActive, credential)
 
-      expect(mockConsentDbUpdate).toHaveBeenLastCalledWith(completeConsentActive)
-      expect(updatedConsent).toEqual(completeConsentActive)
+      expect(mockConsentDbUpdate).toHaveBeenLastCalledWith(completeConsentActiveNoCredentialID)
+      expect(updatedConsent).toEqual(completeConsentActiveNoCredentialID)
     })
 
     // eslint-disable-next-line max-len
@@ -95,7 +95,7 @@ describe('Tests for src/domain/consents/{ID}/generateChallenge', (): void => {
         .rejects
         .toThrowError('Error updating Database')
 
-      expect(mockConsentDbUpdate).toHaveBeenLastCalledWith(completeConsentActive)
+      expect(mockConsentDbUpdate).toHaveBeenLastCalledWith(completeConsentActiveNoCredentialID)
     })
   })
 
@@ -107,7 +107,7 @@ describe('Tests for src/domain/consents/{ID}/generateChallenge', (): void => {
     })
 
     it('Should resolve successfully', async (): Promise<void> => {
-      expect(await generatePutConsentsRequest(completeConsentActive, externalScopes))
+      expect(await generatePutConsentsRequest(completeConsentActiveNoCredentialID, externalScopes))
         .toStrictEqual(putConsentRequestBody)
     })
 

--- a/test/unit/domain/consents/revoke.test.ts
+++ b/test/unit/domain/consents/revoke.test.ts
@@ -34,61 +34,18 @@ import {
   revokeConsentStatus
 } from '~/domain/consents/revoke'
 import { Consent } from '~/model/consent'
+import {
+  partialConsentActive, completeConsentActive, completeConsentRevoked,
+  partialConsentRevoked, partialConsentActiveConflictingInitiatorId
+} from 'test/unit/data/data'
 
 const mockConsentUpdate = jest.spyOn(consentDB, 'update')
 const mockLoggerPush = jest.spyOn(Logger, 'push')
 const mockLoggerError = jest.spyOn(Logger, 'error')
 
-/*
- * Mock Consent Resources
- */
-const partialConsentActive: Consent = {
-  id: '1234',
-  initiatorId: 'pisp-2342-2233',
-  participantId: 'dfsp-3333-2123',
-  status: 'ACTIVE'
-}
-
-const partialConsentActive2: Consent = {
-  id: '1234',
-  initiatorId: 'pi2-2233',
-  participantId: 'dfs333-2123',
-  status: 'ACTIVE'
-}
-
-const partialConsentRevoked: Consent = {
-  id: '1234',
-  initiatorId: 'pisp-2342-2233',
-  participantId: 'dfsp-3333-2123',
-  revokedAt: 'now',
-  status: 'REVOKED'
-}
-
-const completeConsentRevoked: Consent = {
-  id: '1234',
-  initiatorId: 'pisp-2342-2233',
-  participantId: 'dfsp-3333-2123',
-  status: 'REVOKED',
-  revokedAt: 'now',
-  credentialType: 'FIDO',
-  credentialStatus: 'PENDING',
-  credentialChallenge: 'xyhdushsoa82w92mzs='
-}
-
-const completeConsentActive: Consent = {
-  id: '1234',
-  initiatorId: 'pisp-2342-2233',
-  participantId: 'dfsp-3333-2123',
-  credentialId: '123',
-  credentialType: 'FIDO',
-  status: 'ACTIVE',
-  credentialStatus: 'PENDING',
-  credentialChallenge: 'xyhdushsoa82w92mzs='
-}
-
 const requestBody: SDKStandardComponents.PatchConsentsRequest = {
   status: 'REVOKED',
-  revokedAt: 'now'
+  revokedAt: '2020-08-19T05:44:18.843Z'
 
 }
 
@@ -132,7 +89,7 @@ describe('server/domain/consents/revoke', (): void => {
       async (): Promise<void> => {
         const revokedConsent = await revokeConsentStatus(completeConsentRevoked)
         expect(revokedConsent).toStrictEqual(completeConsentRevoked)
-        expect(mockLoggerPush).toHaveBeenCalled()
+        expect(mockLoggerPush).toHaveBeenCalledWith('Previously revoked consent was asked to be revoked')
         expect(mockConsentUpdate).not.toHaveBeenCalled()
       })
 
@@ -153,7 +110,7 @@ describe('server/domain/consents/revoke', (): void => {
       async (): Promise<void> => {
         mockConsentUpdate.mockRejectedValue(new Error('Test Error'))
 
-        await expect(revokeConsentStatus(partialConsentActive2))
+        await expect(revokeConsentStatus(partialConsentActiveConflictingInitiatorId))
           .rejects
           .toThrowError('Test Error')
 

--- a/test/unit/domain/consents/revoke.test.ts
+++ b/test/unit/domain/consents/revoke.test.ts
@@ -26,7 +26,6 @@
  - Abhimanyu Kapur <abhi.kapur09@gmail.com>
  --------------
  ******/
-import { Request } from '@hapi/hapi'
 import { consentDB } from '~/lib/db'
 import Logger from '@mojaloop/central-services-logger'
 import SDKStandardComponents from '@mojaloop/sdk-standard-components'
@@ -39,44 +38,6 @@ import { Consent } from '~/model/consent'
 const mockConsentUpdate = jest.spyOn(consentDB, 'update')
 const mockLoggerPush = jest.spyOn(Logger, 'push')
 const mockLoggerError = jest.spyOn(Logger, 'error')
-
-/*
- * Mock Request Resources
- */
-// @ts-ignore
-const request: Request = {
-  headers: {
-    'fspiop-source': 'pisp-2342-2233',
-    'fspiop-destination': 'dfsp-3333-2123'
-  },
-  params: {
-    id: '1234'
-  },
-  payload: {
-    id: '1234',
-    requestId: '475234',
-    initiatorId: 'pispa',
-    participantId: 'sfsfdf23',
-    scopes: [
-      {
-        accountId: '3423',
-        actions: ['acc.getMoney', 'acc.sendMoney']
-      },
-      {
-        accountId: '232345',
-        actions: ['acc.accessSaving']
-      }
-    ],
-    credential: null
-  }
-}
-
-// @ts-ignore
-const requestNoHeaders: Request = {
-  params: {
-    id: '1234'
-  }
-}
 
 /*
  * Mock Consent Resources
@@ -183,30 +144,34 @@ describe('server/domain/consents/revoke', (): void => {
   })
 
   describe('generatePatchRevokedConsentRequest', (): void => {
-    it('Should return correct request body', (): void => {
-      expect(generatePatchRevokedConsentRequest(completeConsentRevoked))
-        .toStrictEqual(requestBody)
-    })
+    it('Should return correct request body when complete consent given',
+      (): void => {
+        expect(generatePatchRevokedConsentRequest(completeConsentRevoked))
+          .toStrictEqual(requestBody)
+      })
 
-    it('Should also return correct request body', async (): Promise<void> => {
-      expect(generatePatchRevokedConsentRequest(partialConsentRevoked))
-        .toStrictEqual(requestBody)
-    })
+    it('Should return correct request body even if partial consent given',
+      (): void => {
+        expect(generatePatchRevokedConsentRequest(partialConsentRevoked))
+          .toStrictEqual(requestBody)
+      })
 
-    it('Should throw an error as consent is null value', (): void => {
-      expect((): void => {
-        generatePatchRevokedConsentRequest(
-          null as unknown as Consent)
-      }).toThrow()
-    })
+    it('Should throw an error as consent is null value',
+      (): void => {
+        expect((): void => {
+          generatePatchRevokedConsentRequest(
+            null as unknown as Consent)
+        }).toThrow()
+      })
 
-    it('Should throw an error as consent is ACTIVE', (): void => {
+    it('Should throw an error as consent is ACTIVE',
+      (): void => {
       // Reset Consent Status
-      completeConsentActive.status = 'ACTIVE'
+        completeConsentActive.status = 'ACTIVE'
 
-      expect((): void => {
-        generatePatchRevokedConsentRequest(completeConsentActive)
-      }).toThrowError('Attempting to generate request for non-revoked consent!')
-    })
+        expect((): void => {
+          generatePatchRevokedConsentRequest(completeConsentActive)
+        }).toThrowError('Attempting to generate request for non-revoked consent!')
+      })
   })
 })

--- a/test/unit/domain/validators.test.ts
+++ b/test/unit/domain/validators.test.ts
@@ -30,132 +30,82 @@ import { Request } from '@hapi/hapi'
 import { Enum } from '@mojaloop/central-services-shared'
 import { Consent } from '~/model/consent'
 import * as validators from '~/domain/validators'
-
-/*
- * Mock Request Resources
- */
-// @ts-ignore
-const request: Request = {
-  headers: {
-    'fspiop-source': 'pisp-2342-2233',
-    'fspiop-destination': 'dfsp-3333-2123'
-  },
-  params: {
-    id: '1234'
-  },
-  payload: {
-    id: '1234',
-    requestId: '475234',
-    initiatorId: 'pispa',
-    participantId: 'sfsfdf23',
-    scopes: [
-      {
-        accountId: '3423',
-        actions: ['acc.getMoney', 'acc.sendMoney']
-      },
-      {
-        accountId: '232345',
-        actions: ['acc.accessSaving']
-      }
-    ],
-    credential: null
-  }
-}
-
-// @ts-ignore
-const requestNoHeaders: Request = {
-  params: {
-    id: '1234'
-  }
-}
-
-/*
- * Mock Consent Resources
- */
-const partialConsentActive: Consent = {
-  id: '1234',
-  initiatorId: 'pisp-2342-2233',
-  participantId: 'dfsp-3333-2123',
-  status: 'ACTIVE'
-}
-
-const partialConsentActive2: Consent = {
-  id: '1234',
-  initiatorId: 'pi2-2233',
-  participantId: 'dfs333-2123',
-  status: 'ACTIVE'
-}
-
+import {
+  request,
+  partialConsentActive,
+  partialConsentActiveConflictingInitiatorId,
+  requestNoHeaders
+} from '../data/data'
 
 describe('isConsentRequestInitiatedByValidSource', (): void => {
-    it('Should return true', (): void => {
-        expect(
-        validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request))
-        .toBe(true)
-    })
+  it('Should return true', (): void => {
+    expect(
+      validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request))
+      .toBe(true)
+  })
 
-    it('Should return false because consent is null', (): void => {
-        expect(validators.isConsentRequestInitiatedByValidSource(
-        null as unknown as Consent, request))
-        .toBeFalsy()
-    })
+  it('Should return false because consent is null', (): void => {
+    expect(validators.isConsentRequestInitiatedByValidSource(
+      null as unknown as Consent, request))
+      .toBeFalsy()
+  })
 
-    it('Should return false because initiator ID does not match', (): void => {
-        expect(
-        validators.isConsentRequestInitiatedByValidSource(partialConsentActive2, request))
-        .toBeFalsy()
-    })
+  it('Should return false because initiator ID does not match', (): void => {
+    expect(
+      validators.isConsentRequestInitiatedByValidSource(partialConsentActiveConflictingInitiatorId, request))
+      .toBeFalsy()
+  })
 
-    it('Should return false as source header is null', (): void => {
-        request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = null as unknown as string
+  it('Should return false as source header is null', (): void => {
+    request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = null as unknown as string
 
-        expect(
-        validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request)
-        ).toBe(false)
+    expect(
+      validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request)
+    ).toBe(false)
 
-        // Reset header
-        request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = 'pisp-2342-2233'
-    })
+    // Reset header
+    request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = 'pisp-2342-2233'
+  })
 
-    it('Should return false as source header is empty string', (): void => {
-        request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = ''
+  it('Should return false as source header is empty string', (): void => {
+    request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = ''
 
-        expect(
-        validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request)
-        ).toBe(false)
+    expect(
+      validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request)
+    ).toBe(false)
 
-        // Reset header
-        request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = 'pisp-2342-2233'
-    })
+    // Reset header
+    request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = 'pisp-2342-2233'
+  })
 
-    it('Should throw an error as request headers are missing', (): void => {
-        expect((): void => {
-        validators.isConsentRequestInitiatedByValidSource(
-            partialConsentActive, requestNoHeaders as Request)
-        }).toThrowError()
-    })
+  it('Should throw an error as request headers are missing', (): void => {
+    expect((): void => {
+      validators.isConsentRequestInitiatedByValidSource(
+        partialConsentActive, requestNoHeaders as Request)
+    }).toThrowError()
+  })
 
-    it('Should return false as consent is null and request header is empty string',
-        (): void => {
-        request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = ''
-
-        expect(
-            validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request)
-        ).toBe(false)
-
-        // Reset header
-        request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = 'pisp-2342-2233'
-    })
-
-    it('Should return false as consent is null and source header is null',
+  it('Should return false as consent is null and request header is empty string',
     (): void => {
-        request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = null as unknown as string
+      request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = ''
 
-        expect(
+      expect(
         validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request)
-        ).toBe(false)
+      ).toBe(false)
 
-        // Reset header
-        request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = 'pisp-2342-2233'
+      // Reset header
+      request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = 'pisp-2342-2233'
+    })
+
+  it('Should return false as consent is null and source header is null',
+    (): void => {
+      request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = null as unknown as string
+
+      expect(
+        validators.isConsentRequestInitiatedByValidSource(partialConsentActive, request)
+      ).toBe(false)
+
+      // Reset header
+      request.headers[Enum.Http.Headers.FSPIOP.SOURCE] = 'pisp-2342-2233'
     })
 })

--- a/test/unit/model/consent.test.ts
+++ b/test/unit/model/consent.test.ts
@@ -293,7 +293,7 @@ describe('src/model/consent', (): void => {
           .rejects.toThrowError(NotFoundError)
       })
 
-    it('inserts consent, updates it to revoke it but then does not update a REVOKED consent',
+    it('inserts consent, updates it to REVOKE status and then fails to update a REVOKED consent',
       async (): Promise<void> => {
         // Action
         await Db<Consent>('Consent').del()

--- a/test/unit/seeds/consent.test.ts
+++ b/test/unit/seeds/consent.test.ts
@@ -19,6 +19,7 @@
  - Name Surname <name.surname@gatesfoundation.com>
 
  - Ahan Gupta <ahangupta.96@gmail.com>
+ - Abhimanyu Kapur <abhi.kapur09@gmail.com>
 
  --------------
  ******/
@@ -42,9 +43,10 @@ describe('testing Consent table', (): void => {
   it('should properly select all the entries in the Consent table', async (): Promise<void> => {
     expect(db).toBeDefined()
     const users: Knex.QueryBuilder[] = await db.from('Consent').select('*')
-    expect(users.length).toEqual(3)
+    expect(users.length).toEqual(5)
     expect(users[0]).toMatchObject({
       id: '123',
+      status: 'ACTIVE',
       initiatorId: 'PISPA',
       participantId: 'DFSPA',
       credentialId: null,
@@ -55,6 +57,7 @@ describe('testing Consent table', (): void => {
     })
     expect(users[1]).toMatchObject({
       id: '124',
+      status: 'ACTIVE',
       initiatorId: 'PISPB',
       participantId: 'DFSPA',
       credentialId: '9876',
@@ -65,6 +68,7 @@ describe('testing Consent table', (): void => {
     })
     expect(users[2]).toMatchObject({
       id: '125',
+      status: 'ACTIVE',
       initiatorId: 'PISPC',
       participantId: 'DFSPA',
       credentialId: '9875',
@@ -72,6 +76,30 @@ describe('testing Consent table', (): void => {
       credentialStatus: 'VERIFIED',
       credentialPayload: 'string_representing_public_key_a',
       credentialChallenge: 'string_representing_challenge_b'
+    })
+    expect(users[3]).toMatchObject({
+      id: '126',
+      status: 'REVOKED',
+      initiatorId: 'PISPC',
+      participantId: 'DFSPA',
+      credentialId: '9875',
+      credentialType: 'FIDO',
+      credentialStatus: 'VERIFIED',
+      credentialPayload: 'string_representing_public_key_a',
+      credentialChallenge: 'string_representing_challenge_b',
+      revokedAt: '2011-10-05T14:48:00.000Z'
+    })
+    expect(users[4]).toMatchObject({
+      id: '127',
+      status: 'REVOKED',
+      initiatorId: 'PISPA',
+      participantId: 'DFSPA',
+      credentialId: null,
+      credentialType: null,
+      credentialStatus: null,
+      credentialPayload: null,
+      credentialChallenge: null,
+      revokedAt: '2020-08-19T05:44:18.843Z'
     })
   })
 })
@@ -117,27 +145,46 @@ describe('testing that constraints are enforced in the consent table', (): void 
   it('should properly enforce the non-nullable constraint for initiatorId', async (): Promise<void> => {
     expect(db).toBeDefined()
     await expect(db.from('Consent').insert({
-      id: '126',
+      id: '128',
+      status: 'ACTIVE',
       initiatorId: null,
       participantId: 'DFSPA',
       credentialId: null,
       credentialType: null,
       credentialStatus: null,
       credentialPayload: null,
-      credentialChallenge: null
+      credentialChallenge: null,
+      revokedAt: null
     })).rejects.toThrow()
   })
   it('should properly enforce the non-nullable constraint for participantId', async (): Promise<void> => {
     expect(db).toBeDefined()
     await expect(db.from('Consent').insert({
-      id: '126',
+      id: '128',
+      status: 'ACTIVE',
       initiatorId: 'PISPA',
       participantId: null,
       credentialId: null,
       credentialType: null,
       credentialStatus: null,
       credentialPayload: null,
-      credentialChallenge: null
+      credentialChallenge: null,
+      revokedAt: null
+    })).rejects.toThrow()
+  })
+  it('should properly enforce the non-nullable constraint for status', async (): Promise<void> => {
+    expect(db).toBeDefined()
+    await expect(db.from('Consent').insert({
+      id: '128',
+      status: null,
+      initiatorId: 'PISPA',
+      participantId: null,
+      credentialId: null,
+      credentialType: null,
+      credentialStatus: null,
+      credentialPayload: null,
+      credentialChallenge: null,
+      revokedAt: null
     })).rejects.toThrow()
   })
 })

--- a/test/unit/server/handlers/consents.test.ts
+++ b/test/unit/server/handlers/consents.test.ts
@@ -26,57 +26,17 @@
  - Abhimanyu Kapur <abhi.kapur09@gmail.com>
  --------------
  ******/
-import { Request, ResponseToolkit, ResponseObject } from '@hapi/hapi'
+import { Request, ResponseToolkit } from '@hapi/hapi'
+import { Enum } from '@mojaloop/central-services-shared'
 import { post } from '~/server/handlers/consents'
 import * as Domain from '~/domain/consents'
 import Logger from '@mojaloop/central-services-logger'
+import { requestWithPayloadScopes, h } from 'test/unit/data/data'
 
 const mockStoreConsent = jest.spyOn(Domain, 'createAndStoreConsent')
 const mockIsPostRequestValid = jest.spyOn(Domain, 'isPostConsentRequestValid')
 const mockLoggerPush = jest.spyOn(Logger, 'push')
 const mockLoggerError = jest.spyOn(Logger, 'error')
-
-/*
- * Mock Request Resources
- */
-// @ts-ignore
-const request: Request = {
-  headers: {
-    fspiopsource: 'pisp-2342-2233',
-    fspiopdestination: 'dfsp-3333-2123'
-  },
-  params: {
-    id: '1234'
-  },
-  payload: {
-    id: '1234',
-    requestId: '475234',
-    initiatorId: 'pispa',
-    participantId: 'sfsfdf23',
-    scopes: [
-      {
-        accountId: '3423',
-        actions: ['acc.getMoney', 'acc.sendMoney']
-      },
-      {
-        accountId: '232345',
-        actions: ['acc.accessSaving']
-      }
-    ],
-    credential: null
-  }
-}
-
-// @ts-ignore
-const h: ResponseToolkit = {
-  response: (): ResponseObject => {
-    return {
-      code: (num: number): ResponseObject => {
-        return num as unknown as ResponseObject
-      }
-    } as unknown as ResponseObject
-  }
-}
 
 describe('server/handlers/consents', (): void => {
   beforeAll((): void => {
@@ -95,12 +55,12 @@ describe('server/handlers/consents', (): void => {
   it('Should return 202 success code',
     async (): Promise<void> => {
       const response = await post(
-        request as Request,
+        requestWithPayloadScopes as Request,
         h as ResponseToolkit
       )
-      expect(response).toBe(202)
+      expect(response.statusCode).toBe(Enum.Http.ReturnCodes.ACCEPTED.CODE)
       jest.runAllImmediates()
-      expect(mockStoreConsent).toHaveBeenCalledWith(request)
+      expect(mockStoreConsent).toHaveBeenCalledWith(requestWithPayloadScopes)
       expect(setImmediate).toHaveBeenCalled()
     })
 
@@ -109,11 +69,11 @@ describe('server/handlers/consents', (): void => {
       mockIsPostRequestValid.mockReturnValueOnce(false)
 
       const response = await post(
-        request as Request,
+        requestWithPayloadScopes as Request,
         h as ResponseToolkit
       )
-      expect(response).toBe(400)
-      expect(mockIsPostRequestValid).toHaveBeenCalledWith(request)
+      expect(response.statusCode).toBe(Enum.Http.ReturnCodes.ACCEPTED.CODE)
+      expect(mockIsPostRequestValid).toHaveBeenCalledWith(requestWithPayloadScopes)
 
       expect(setImmediate).not.toHaveBeenCalled()
       expect(mockStoreConsent).not.toHaveBeenCalled()
@@ -124,12 +84,12 @@ describe('server/handlers/consents', (): void => {
       mockStoreConsent.mockRejectedValueOnce(
         new Error('Error Registering Consent'))
 
-      const response = await post(request as Request, h as ResponseToolkit)
-      expect(response).toBe(202)
+      const response = await post(requestWithPayloadScopes as Request, h as ResponseToolkit)
+      expect(response.statusCode).toBe(Enum.Http.ReturnCodes.ACCEPTED.CODE)
       jest.runAllImmediates()
 
       expect(setImmediate).toHaveBeenCalled()
-      expect(mockStoreConsent).toHaveBeenLastCalledWith(request)
+      expect(mockStoreConsent).toHaveBeenLastCalledWith(requestWithPayloadScopes)
       expect(mockStoreConsent).not.toHaveLastReturnedWith('')
     })
 })

--- a/test/unit/server/handlers/consents.test.ts
+++ b/test/unit/server/handlers/consents.test.ts
@@ -72,7 +72,7 @@ describe('server/handlers/consents', (): void => {
         requestWithPayloadScopes as Request,
         h as ResponseToolkit
       )
-      expect(response.statusCode).toBe(Enum.Http.ReturnCodes.ACCEPTED.CODE)
+      expect(response.statusCode).toBe(Enum.Http.ReturnCodes.BADREQUEST.CODE)
       expect(mockIsPostRequestValid).toHaveBeenCalledWith(requestWithPayloadScopes)
 
       expect(setImmediate).not.toHaveBeenCalled()

--- a/test/unit/server/handlers/consents/{ID}/generateChallenge.test.ts
+++ b/test/unit/server/handlers/consents/{ID}/generateChallenge.test.ts
@@ -117,7 +117,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
           )
       })
 
-    it('Should finish without any errors, NOT generating challenge or updating credentials, and making outgoing call',
+    it('Should resolve successfully, not generating challenge, not updating credentials, and making outgoing call',
       async (): Promise<void> => {
         mockConsentDbRetrieve.mockResolvedValueOnce(completeConsentActive)
         await expect(Handler.generateChallengeAndPutConsent(request, completeConsentActive.id)).resolves.toBeUndefined()
@@ -138,7 +138,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
         expect(mockUpdateConsentCredential).not.toHaveBeenCalled()
       })
 
-    it('Should throw an error due revoked consent', async (): Promise<void> => {
+    it('Should throw an error due to revoked consent', async (): Promise<void> => {
       mockConsentDbRetrieve.mockResolvedValueOnce(completeConsentRevoked)
       await expect(Handler.generateChallengeAndPutConsent(request, completeConsentRevoked.id))
         .rejects.toThrowError('Revoked Consent')
@@ -156,7 +156,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
       expect(mockPutConsents).not.toHaveBeenCalled()
     })
 
-    it('Should throw an error due to error retrieving consent from database', async (): Promise<void> => {
+    it('Should propagate error in retrieving consent from database', async (): Promise<void> => {
       mockConsentDbRetrieve.mockRejectedValueOnce(new Error('Error retrieving consent'))
 
       await expect(Handler.generateChallengeAndPutConsent(request, partialConsentActive.id))
@@ -175,7 +175,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
       expect(mockPutConsents).not.toHaveBeenCalled()
     })
 
-    it('Should throw an error due to invalid request from database', async (): Promise<void> => {
+    it('Should throw an error due to invalid request', async (): Promise<void> => {
       mockIsConsentRequestValid.mockReturnValueOnce(false)
 
       await expect(Handler.generateChallengeAndPutConsent(request, partialConsentActive.id))
@@ -194,7 +194,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
       expect(mockPutConsents).not.toHaveBeenCalled()
     })
 
-    it('Should throw an error due to error updating credentials in database', async (): Promise<void> => {
+    it('Should propagate error in updating credentials in database', async (): Promise<void> => {
       mockUpdateConsentCredential.mockRejectedValueOnce(new Error('Error updating db'))
 
       await expect(Handler.generateChallengeAndPutConsent(request, partialConsentActive.id))
@@ -213,7 +213,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
       expect(mockPutConsents).not.toHaveBeenCalled()
     })
 
-    it('Should throw an error due to error in challenge generation', async (): Promise<void> => {
+    it('Should propagate error in challenge generation', async (): Promise<void> => {
       mockGenerate.mockRejectedValueOnce(new Error('Error generating challenge'))
 
       await expect(Handler.generateChallengeAndPutConsent(request, partialConsentActive.id))
@@ -232,7 +232,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
       expect(mockPutConsents).not.toHaveBeenCalled()
     })
 
-    it('Should throw an error due to error in PUT consents/{id}',
+    it('Should propagate error in making outgoing PUT consents/{id}',
       async (): Promise<void> => {
         mockPutConsents.mockRejectedValueOnce(new Error('Could not establish connection'))
 
@@ -255,7 +255,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
           )
       })
 
-    it('Should throw an error due to error in generating PUT request body',
+    it('Should propagate error in generating PUT request body',
       async (): Promise<void> => {
         mockGeneratePutConsentsRequest.mockRejectedValueOnce(new Error('Test'))
 
@@ -274,7 +274,7 @@ describe('server/handlers/consents/{ID}/generateChallenge', (): void => {
         expect(mockPutConsents).not.toHaveBeenCalled()
       })
 
-    it('Should log an error due to ACTIVE credential in consent',
+    it('Should throw an error due to ACTIVE credential in consent',
       async (): Promise<void> => {
         mockConsentDbRetrieve.mockResolvedValueOnce(completeConsentActiveCredential)
         await expect(Handler.generateChallengeAndPutConsent(

--- a/test/unit/server/handlers/consents/{ID}/revoke.test.ts
+++ b/test/unit/server/handlers/consents/{ID}/revoke.test.ts
@@ -50,7 +50,7 @@ const mockConsentRetrieve = jest.spyOn(consentDB, 'retrieve')
 const mockLoggerPush = jest.spyOn(Logger, 'push')
 const mockLoggerError = jest.spyOn(Logger, 'error')
 
-const consentId = '1234'
+const consentId = partialConsentActive.id
 
 const requestBody: SDKStandardComponents.PatchConsentsRequest = {
   status: 'REVOKED',
@@ -93,7 +93,7 @@ describe('server/handlers/consents', (): void => {
           )
       })
 
-    it('Should also resolve with no errors if consent retrieved is already revoked',
+    it('Should also resolve successfully even if consent retrieved is already revoked',
       async (): Promise<void> => {
         mockConsentRetrieve.mockResolvedValueOnce(completeConsentRevoked)
         mockRevokeConsentStatus.mockResolvedValueOnce(completeConsentRevoked)

--- a/test/unit/server/handlers/consents/{ID}/revoke.test.ts
+++ b/test/unit/server/handlers/consents/{ID}/revoke.test.ts
@@ -26,7 +26,7 @@
  - Abhimanyu Kapur <abhi.kapur09@gmail.com>
  --------------
  ******/
-import { Request, ResponseToolkit, ResponseObject } from '@hapi/hapi'
+import { Request, ResponseToolkit } from '@hapi/hapi'
 import * as Handler from '~/server/handlers/consents/{ID}/revoke'
 import { thirdPartyRequest } from '~/lib/requests'
 import * as Domain from '~/domain/consents/revoke'
@@ -35,7 +35,10 @@ import { consentDB } from '~/lib/db'
 import { Enum } from '@mojaloop/central-services-shared'
 import Logger from '@mojaloop/central-services-logger'
 import SDKStandardComponents from '@mojaloop/sdk-standard-components'
-import { Consent } from '~/model/consent'
+import {
+  request, h, partialConsentRevoked,
+  partialConsentActive, completeConsentRevoked
+} from 'test/unit/data/data'
 
 const mockRevokeConsentStatus = jest.spyOn(Domain, 'revokeConsentStatus')
 const mockPatchConsents = jest.spyOn(thirdPartyRequest, 'patchConsents')
@@ -47,84 +50,11 @@ const mockConsentRetrieve = jest.spyOn(consentDB, 'retrieve')
 const mockLoggerPush = jest.spyOn(Logger, 'push')
 const mockLoggerError = jest.spyOn(Logger, 'error')
 
-/*
- * Mock Request Resources
- */
-// @ts-ignore
-const request: Request = {
-  headers: {
-    'fspiop-source': 'pisp-2342-2233',
-    'fspiop-destination': 'dfsp-3333-2123'
-  },
-  params: {
-    id: '1234'
-  },
-  payload: {
-    id: '1234',
-    requestId: '475234',
-    initiatorId: 'pispa',
-    participantId: 'sfsfdf23',
-    scopes: [
-      {
-        accountId: '3423',
-        actions: ['acc.getMoney', 'acc.sendMoney']
-      },
-      {
-        accountId: '232345',
-        actions: ['acc.accessSaving']
-      }
-    ],
-    credential: null
-  }
-}
-
-// @ts-ignore
-const h: ResponseToolkit = {
-  response: (): ResponseObject => {
-    return {
-      code: (num: number): ResponseObject => {
-        return {
-          statusCode: num
-        } as unknown as ResponseObject
-      }
-    } as unknown as ResponseObject
-  }
-}
-
-/*
- * Mock Consent Resources
- */
-const partialConsentActive: Consent = {
-  id: '1234',
-  initiatorId: 'pisp-2342-2233',
-  participantId: 'dfsp-3333-2123',
-  status: 'ACTIVE'
-}
-
-const partialConsentRevoked: Consent = {
-  id: '1234',
-  initiatorId: 'pisp-2342-2233',
-  participantId: 'dfsp-3333-2123',
-  revokedAt: 'now',
-  status: 'REVOKED'
-}
-
-const completeConsentRevoked: Consent = {
-  id: '1234',
-  initiatorId: 'pisp-2342-2233',
-  participantId: 'dfsp-3333-2123',
-  status: 'REVOKED',
-  revokedAt: 'now',
-  credentialType: 'FIDO',
-  credentialStatus: 'PENDING',
-  credentialChallenge: 'xyhdushsoa82w92mzs='
-}
-
 const consentId = '1234'
 
 const requestBody: SDKStandardComponents.PatchConsentsRequest = {
   status: 'REVOKED',
-  revokedAt: 'now'
+  revokedAt: '2020-08-19T05:44:18.843Z'
 
 }
 

--- a/test/unit/server/handlers/consents/{ID}/revoke.test.ts
+++ b/test/unit/server/handlers/consents/{ID}/revoke.test.ts
@@ -145,7 +145,7 @@ describe('server/handlers/consents', (): void => {
   })
 
   describe('validateRequestAndRevokeConsent', (): void => {
-    it('Should finish with no errors',
+    it('Should resolve successfully with no errors',
       async (): Promise<void> => {
         await expect(Handler.validateRequestAndRevokeConsent(request))
           .resolves.toBe(undefined)
@@ -163,7 +163,7 @@ describe('server/handlers/consents', (): void => {
           )
       })
 
-    it('Should also resolve with no errors',
+    it('Should also resolve with no errors if consent retrieved is already revoked',
       async (): Promise<void> => {
         mockConsentRetrieve.mockResolvedValueOnce(completeConsentRevoked)
         mockRevokeConsentStatus.mockResolvedValueOnce(completeConsentRevoked)
@@ -198,7 +198,7 @@ describe('server/handlers/consents', (): void => {
         expect(mockPatchConsents).not.toBeCalled()
       })
 
-    it('Should throw an error due to invalid request',
+    it('Should throw an error if request is invalid',
       async (): Promise<void> => {
         mockIsConsentRequestValid.mockReturnValueOnce(false)
         await expect(Handler.validateRequestAndRevokeConsent(request))


### PR DESCRIPTION
[x] - Increase Unit Test Coverage - with emphasis on unlinking flow
[x] - Add tests where generatePatchConsentRequest is called with ACTIVE/ invalid Consent argument
[x] - Add tests where revokeConsentStatus is called with REVOKED/ invalid Consent argument
[x] - Seed with data with REVOKED consent status + add tests for revoke related logic
[x] - Create a central data file for all common mocked resources used in unit tests. Refactor tests to use the data file
[x] - Improve test descriptions for clarity where needed
