### PR TITLE
fix(ci/cd): explicitly disable `license-scan` and `image-scan` steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,27 +547,29 @@ workflows:
             tags:
               only: /.*/
 
-      - license-scan:
-          context: org-global
-          requires:
-            - build-local
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only:
-                - master
+      # Disabled temporarily until we can ignore devDependencies
+      # see mojaloop/mojaloop#415 for more information
+      # - license-scan:
+      #     context: org-global
+      #     requires:
+      #       - build-local
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #       branches:
+      #         only:
+      #           - master
 
-      - image-scan:
-          context: org-global
-          requires:
-            - build-local
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only:
-                - master
+      # - image-scan:
+      #     context: org-global
+      #     requires:
+      #       - build-local
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #       branches:
+      #         only:
+      #           - master
 
       # New commits to master release automatically
       - release:


### PR DESCRIPTION
ugh circleci still failed that last run