### PR TITLE
Fix unhandled promise rejection for revoke test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
       lines: 90
     }
   },
+  testTimeout: 10000,
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: '<rootDir>/'
   }),

--- a/test/unit/server/handlers/consents/{ID}/revoke.test.ts
+++ b/test/unit/server/handlers/consents/{ID}/revoke.test.ts
@@ -74,6 +74,10 @@ describe('server/handlers/consents', (): void => {
     jest.clearAllMocks()
   })
 
+  afterAll((): void => {
+    jest.clearAllMocks
+  })
+
   describe('validateRequestAndRevokeConsent', (): void => {
     it('Should resolve successfully with no errors',
       async (): Promise<void> => {
@@ -143,7 +147,7 @@ describe('server/handlers/consents', (): void => {
 
     it('Should propagate errors from patchConsents()',
       async (): Promise<void> => {
-        mockPatchConsents.mockRejectedValue(new Error('Test Error'))
+        mockPatchConsents.mockRejectedValueOnce(new Error('Test Error'))
         await expect(Handler.validateRequestAndRevokeConsent(request))
           .rejects.toThrowError('Test Error')
 


### PR DESCRIPTION
- Clear mocks after so that mocks do not persist to next test
- Issue was caused by mock rejected promise in handler - handler intentionally does not handle errors (shall be addressed properly in another issue)